### PR TITLE
fix: union order to ensure deterministic output

### DIFF
--- a/src/renderer/generic/render-type-union.ts
+++ b/src/renderer/generic/render-type-union.ts
@@ -1,3 +1,3 @@
 export const renderTypeUnion = (types: string[]): string => {
-    return types.join(' | ');
+    return types.sort().join(' | ');
 };

--- a/test/renderer/field/render-prop-any.test.ts
+++ b/test/renderer/field/render-prop-any.test.ts
@@ -41,7 +41,7 @@ describe('A renderPropAny function', () => {
         }
         `);
 
-        expect(renderPropAny(field)).to.equal('"Left-aligned" | "Center-aligned"');
+        expect(renderPropAny(field)).to.equal('"Center-aligned" | "Left-aligned"');
     });
 
     it('can evaluate a "Symbol" type with missing validations', () => {

--- a/test/renderer/field/render-prop-array.test.ts
+++ b/test/renderer/field/render-prop-array.test.ts
@@ -77,7 +77,7 @@ describe('A renderPropArray function', () => {
         }
         `);
 
-    expect(renderPropArray(field, createDefaultContext())).to.equal('("Feature" | "Benefit" | "Tech spec" | "Other")[]');
+    expect(renderPropArray(field, createDefaultContext())).to.equal('("Benefit" | "Feature" | "Other" | "Tech spec")[]');
   });
 
   it('can evaluate an "Array" of "Link" with "linkContentType" validation', () => {


### PR DESCRIPTION
We don't want to rely on the deterministic behavior of contentful export and how the content is created. This change ensures union types are always rendered in the same order. 

The changes in the tests are reflecting this behavour.

solves: #155