### PR TITLE
🐛 Fix renderTypeArray to handle unions

### DIFF
--- a/src/renderer/generic/render-type-array.ts
+++ b/src/renderer/generic/render-type-array.ts
@@ -1,3 +1,3 @@
 export const renderTypeArray = (type: string): string => {
-    return `${type}[]`;
+    return `(${type})[]`;
 };


### PR DESCRIPTION
If the `renderTypeArray` renders a union of types, only the last type would be an array. 

Before this change an array of a union type would render like this:
```
Foo | Bar[]
```

After this change an array of a union type would render like this:
```
(Foo | Bar)[]
```