### PR TITLE
fix: rendering arrays of unions

### DIFF
--- a/src/renderer/field/render-prop-array.ts
+++ b/src/renderer/field/render-prop-array.ts
@@ -16,7 +16,13 @@ export const renderPropArray = (field: Field, context: RenderContext): string =>
         const validation = inValidations(field.items);
 
         if (validation?.length > 0) {
-            return renderTypeArray(`(${renderTypeUnion(validation.map((val: string) => renderTypeLiteral(val)))})`);
+            const validationsTypes = validation.map((val: string) => renderTypeLiteral(val));
+
+            if (validationsTypes.length > 1) {
+                return renderTypeArray(`(${renderTypeUnion(validationsTypes)})`);
+            }
+
+            return renderTypeArray(`${renderTypeUnion(validationsTypes)}`);
         }
 
         return renderTypeArray('Contentful.EntryFields.Symbol');

--- a/src/renderer/generic/render-type-array.ts
+++ b/src/renderer/generic/render-type-array.ts
@@ -1,3 +1,3 @@
 export const renderTypeArray = (type: string): string => {
-    return `(${type})[]`;
+    return `${type}[]`;
 };


### PR DESCRIPTION
Hey @tatemz, 
your change caused several tests to fail (just realised I didn't run them on your PR 🤦 )

I partially changed it back and added a guard back to ensure the `(` `)` in the right place. 
Would be good to know if this also solves your issue :) 
