### PR TITLE
feat: add appendTypes() method

### DIFF
--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -50,6 +50,12 @@ export default class CFDefinitionsBuilder {
         return this;
     };
 
+    public appendTypes = (models: CFContentType[]): CFDefinitionsBuilder => {
+        for (const model of models)  this.appendType(model);
+
+        return this;
+    };
+
     public write = async (dir: string, writeCallback: WriteCallback): Promise<void> => {
         this.addIndexFile();
 


### PR DESCRIPTION
A common use case of CFDefinitionsBuilder would be to fetch all content types using `environment.getContentTypes()` and pass it along. Then, you need to manually add types one by one, instead of passing it all at once. This method makes it easier.