### PR TITLE
feat: switch to named imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ As input a [json file](https://github.com/contentful/contentful-cli/tree/master/
 
 ```typescript
 import * as CFRichTextTypes from '@contentful/rich-text-types';
-import * as Contentful from 'contentful';
+import { Entry, EntryFields } from 'contentful';
 
 export interface TypeArtistFields {
   name: Contentful.EntryFields.Symbol;
@@ -214,16 +214,16 @@ export interface TypeArtistFields {
   bio?: CFRichTextTypes.Block | CFRichTextTypes.Inline;
 }
 
-export type TypeArtist = Contentful.Entry<TypeArtistFields>;
+export type TypeArtist = Entry<TypeArtistFields>;
 
 export interface TypeArtworkFields {
-  name: Contentful.EntryFields.Symbol;
+  name: EntryFields.Symbol;
   type?: 'print' | 'drawing' | 'painting';
-  preview?: Contentful.Asset[];
-  artist: Contentful.Entry<TypeArtistFields>;
+  preview?: Asset[];
+  artist: Entry<TypeArtistFields>;
 }
 
-export type TypeArtwork = Contentful.Entry<TypeArtworkFields>;
+export type TypeArtwork = Entry<TypeArtworkFields>;
 ```
 
 This all only works if you add the [`contentful`](https://www.npmjs.com/package/contentful) package to your target project to get all relevant type definitions.
@@ -249,8 +249,8 @@ Relevant methods to override:
 Set content type renderers:
 
 ```typescript
-import CFDefinitionsBuilder from 'cf-content-types-generator';
 import {
+  CFDefinitionsBuilder,
   DefaultContentTypeRenderer,
   LocalizedContentTypeRenderer,
 } from 'cf-content-types-generator';
@@ -329,21 +329,21 @@ const stringContent = new CFDefinitionsBuilder()
         validations: [],
         disabled: false,
         localized: false,
-        omitted: false
+        omitted: false,
       },
     ],
   })
   .toString();
 
-console.log(stringContent)
+console.log(stringContent);
 
-// import * as Contentful from "contentful";
-// 
+// import { Entry, EntryFields } from "contentful";
+//
 // export interface TypeMyEntryFields {
-//   myField: Contentful.EntryFields.Symbol;
+//   myField: EntryFields.Symbol;
 // }
-// 
-// export type TypeMyEntry = Contentful.Entry<TypeMyEntryFields>;
+//
+// export type TypeMyEntry = Entry<TypeMyEntryFields>;
 ```
 
 # Browser Usage

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import {
   ContentTypeRenderer,
   DefaultContentTypeRenderer,
   LocalizedContentTypeRenderer,
-} from './renderer/type';
+} from './renderer';
 
 // eslint-disable-next-line unicorn/prefer-module
 const contentfulExport = require('contentful-export');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import CFDefinitionsBuilder from './cf-definitions-builder';
+
 export * from './extract-validation';
 export * from './module-name';
 export * from './property-imports';
 export * from './renderer';
 export * from './types';
 export default CFDefinitionsBuilder;
+export { CFDefinitionsBuilder };

--- a/src/property-imports.ts
+++ b/src/property-imports.ts
@@ -10,10 +10,11 @@ export const propertyImports = (
 ): OptionalKind<ImportDeclarationStructure>[] => {
   const filterIgnoredModule = (name: string) => ignoreModule !== context.moduleName(name);
 
-  const moduleImport = (module: string) => {
+  const moduleImport = (module: string): OptionalKind<ImportDeclarationStructure> => {
     return {
       moduleSpecifier: `./${context.moduleName(module)}`,
       namedImports: [context.moduleFieldsName(module)],
+      isTypeOnly: true,
     };
   };
 

--- a/src/renderer/field/render-prop-any.ts
+++ b/src/renderer/field/render-prop-any.ts
@@ -1,7 +1,8 @@
-import { renderTypeLiteral, renderTypeUnion } from '../generic';
 import { Field } from 'contentful';
+import { renderTypeLiteral, renderTypeUnion } from '../generic';
+import { RenderContext } from '../type';
 
-export const renderPropAny = (field: Field): string => {
+export const renderPropAny = (field: Field, context: RenderContext): string => {
   if (field.validations?.length > 0) {
     const includesValidation = field.validations.find((validation) => validation.in);
     if (includesValidation && includesValidation.in) {
@@ -17,5 +18,10 @@ export const renderPropAny = (field: Field): string => {
     }
   }
 
-  return `Contentful.EntryFields.${field.type}`;
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['EntryFields'],
+  });
+
+  return `EntryFields.${field.type}`;
 };

--- a/src/renderer/field/render-prop-any.ts
+++ b/src/renderer/field/render-prop-any.ts
@@ -21,6 +21,7 @@ export const renderPropAny = (field: Field, context: RenderContext): string => {
   context.imports.add({
     moduleSpecifier: 'contentful',
     namedImports: ['EntryFields'],
+    isTypeOnly: true,
   });
 
   return `EntryFields.${field.type}`;

--- a/src/renderer/field/render-prop-array.ts
+++ b/src/renderer/field/render-prop-array.ts
@@ -28,6 +28,7 @@ export const renderPropArray = (field: Field, context: RenderContext): string =>
     context.imports.add({
       moduleSpecifier: 'contentful',
       namedImports: ['EntryFields'],
+      isTypeOnly: true,
     });
 
     return renderTypeArray('EntryFields.Symbol');

--- a/src/renderer/field/render-prop-array.ts
+++ b/src/renderer/field/render-prop-array.ts
@@ -25,7 +25,12 @@ export const renderPropArray = (field: Field, context: RenderContext): string =>
       return renderTypeArray(`${renderTypeUnion(validationsTypes)}`);
     }
 
-    return renderTypeArray('Contentful.EntryFields.Symbol');
+    context.imports.add({
+      moduleSpecifier: 'contentful',
+      namedImports: ['EntryFields'],
+    });
+
+    return renderTypeArray('EntryFields.Symbol');
   }
 
   throw new Error('unhandled array type "' + field.items.type + '"');

--- a/src/renderer/field/render-prop-link.ts
+++ b/src/renderer/field/render-prop-link.ts
@@ -14,7 +14,22 @@ export const renderPropLink = (
       : 'Record<string, any>';
   };
 
-  return field.linkType === 'Entry'
-    ? renderTypeGeneric('Contentful.' + field.linkType, linkContentType(field, context))
-    : 'Contentful.' + field.linkType!;
+  switch (field.linkType) {
+    case 'Entry':
+      context.imports.add({
+        moduleSpecifier: 'contentful',
+        namedImports: ['Entry'],
+      });
+      return renderTypeGeneric(field.linkType, linkContentType(field, context));
+
+    case 'Asset':
+      context.imports.add({
+        moduleSpecifier: 'contentful',
+        namedImports: ['Asset'],
+      });
+      return 'Asset';
+
+    default:
+      throw new Error(`Unknown linkType "${field.linkType}"`);
+  }
 };

--- a/src/renderer/field/render-prop-link.ts
+++ b/src/renderer/field/render-prop-link.ts
@@ -19,6 +19,7 @@ export const renderPropLink = (
       context.imports.add({
         moduleSpecifier: 'contentful',
         namedImports: ['Entry'],
+        isTypeOnly: true,
       });
       return renderTypeGeneric(field.linkType, linkContentType(field, context));
 
@@ -26,6 +27,7 @@ export const renderPropLink = (
       context.imports.add({
         moduleSpecifier: 'contentful',
         namedImports: ['Asset'],
+        isTypeOnly: true,
       });
       return 'Asset';
 

--- a/src/renderer/field/render-prop-richtext.ts
+++ b/src/renderer/field/render-prop-richtext.ts
@@ -6,6 +6,7 @@ export const renderRichText = (field: Field, context: RenderContext): string => 
   context.imports.add({
     moduleSpecifier: '@contentful/rich-text-types',
     namespaceImport: 'CFRichTextTypes',
+    isTypeOnly: true,
   });
   return renderTypeUnion(['CFRichTextTypes.Block', 'CFRichTextTypes.Inline']);
 };

--- a/src/renderer/type/default-content-type-renderer.ts
+++ b/src/renderer/type/default-content-type-renderer.ts
@@ -77,6 +77,7 @@ export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
     context.imports.add({
       moduleSpecifier: 'contentful',
       namedImports: ['Entry'],
+      isTypeOnly: true,
     });
     return renderTypeGeneric('Entry', context.moduleFieldsName(contentType.sys.id));
   }

--- a/src/renderer/type/default-content-type-renderer.ts
+++ b/src/renderer/type/default-content-type-renderer.ts
@@ -44,12 +44,8 @@ export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
     }
   }
 
-  protected addDefaultImports(context: RenderContext): void {
-    context.imports.add({
-      moduleSpecifier: 'contentful',
-      namespaceImport: 'Contentful',
-    });
-  }
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+  protected addDefaultImports(context: RenderContext): void {}
 
   protected renderField(
     field: Field,
@@ -78,6 +74,10 @@ export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
   }
 
   protected renderEntryType(contentType: CFContentType, context: RenderContext): string {
-    return renderTypeGeneric('Contentful.Entry', context.moduleFieldsName(contentType.sys.id));
+    context.imports.add({
+      moduleSpecifier: 'contentful',
+      namedImports: ['Entry'],
+    });
+    return renderTypeGeneric('Entry', context.moduleFieldsName(contentType.sys.id));
   }
 }

--- a/src/renderer/type/localized-content-type-renderer.ts
+++ b/src/renderer/type/localized-content-type-renderer.ts
@@ -73,6 +73,7 @@ export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
     context.imports.add({
       moduleSpecifier: `./${this.FILE_BASE_NAME}`,
       namedImports: ['LocalizedFields', 'LocalizedEntry'],
+      isTypeOnly: true,
     });
 
     for (const structure of context.imports) {

--- a/test/cases/fixtures/01-output.txt
+++ b/test/cases/fixtures/01-output.txt
@@ -1,38 +1,38 @@
-import * as Contentful from "contentful";
+import { Asset, Entry, EntryFields } from "contentful";
 
 export interface TypeBrandFields {
-    companyName: Contentful.EntryFields.Text;
-    logo?: Contentful.Asset;
-    companyDescription?: Contentful.EntryFields.Text;
-    website?: Contentful.EntryFields.Symbol;
-    twitter?: Contentful.EntryFields.Symbol;
-    email?: Contentful.EntryFields.Symbol;
-    phone?: Contentful.EntryFields.Symbol[];
+    companyName: EntryFields.Text;
+    logo?: Asset;
+    companyDescription?: EntryFields.Text;
+    website?: EntryFields.Symbol;
+    twitter?: EntryFields.Symbol;
+    email?: EntryFields.Symbol;
+    phone?: EntryFields.Symbol[];
 }
 
-export type TypeBrand = Contentful.Entry<TypeBrandFields>;
+export type TypeBrand = Entry<TypeBrandFields>;
 
 export interface TypeCategoryFields {
-    title: Contentful.EntryFields.Text;
-    icon?: Contentful.Asset;
-    categoryDescription?: Contentful.EntryFields.Text;
+    title: EntryFields.Text;
+    icon?: Asset;
+    categoryDescription?: EntryFields.Text;
 }
 
-export type TypeCategory = Contentful.Entry<TypeCategoryFields>;
+export type TypeCategory = Entry<TypeCategoryFields>;
 
 export interface TypeProductFields {
-    productName: Contentful.EntryFields.Text;
-    slug?: Contentful.EntryFields.Symbol;
-    productDescription?: Contentful.EntryFields.Text;
-    sizetypecolor?: Contentful.EntryFields.Symbol;
-    image?: Contentful.Asset[];
-    tags?: Contentful.EntryFields.Symbol[];
-    categories?: Contentful.Entry<TypeCategoryFields>[];
-    price?: Contentful.EntryFields.Number;
-    brand?: Contentful.Entry<TypeBrandFields>;
-    quantity?: Contentful.EntryFields.Integer;
-    sku?: Contentful.EntryFields.Symbol;
-    website?: Contentful.EntryFields.Symbol;
+    productName: EntryFields.Text;
+    slug?: EntryFields.Symbol;
+    productDescription?: EntryFields.Text;
+    sizetypecolor?: EntryFields.Symbol;
+    image?: Asset[];
+    tags?: EntryFields.Symbol[];
+    categories?: Entry<TypeCategoryFields>[];
+    price?: EntryFields.Number;
+    brand?: Entry<TypeBrandFields>;
+    quantity?: EntryFields.Integer;
+    sku?: EntryFields.Symbol;
+    website?: EntryFields.Symbol;
 }
 
-export type TypeProduct = Contentful.Entry<TypeProductFields>;
+export type TypeProduct = Entry<TypeProductFields>;

--- a/test/cases/fixtures/01-output.txt
+++ b/test/cases/fixtures/01-output.txt
@@ -1,4 +1,4 @@
-import { Asset, Entry, EntryFields } from "contentful";
+import type { Asset, Entry, EntryFields } from "contentful";
 
 export interface TypeBrandFields {
     companyName: EntryFields.Text;

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -49,12 +49,12 @@ describe('A Contentful definitions builder', () => {
     builder.appendType(modelType);
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
 
                 export interface TypeSysIdFields {
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -80,13 +80,13 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry, EntryFields } from "contentful";
                 
                 export interface TypeSysIdFields {
-                    symbolFieldId: Contentful.EntryFields.Symbol;
+                    symbolFieldId: EntryFields.Symbol;
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -112,13 +112,13 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry, EntryFields } from "contentful";
                 
                 export interface TypeSysIdFields {
-                    symbolFieldId?: Contentful.EntryFields.Symbol;
+                    symbolFieldId?: EntryFields.Symbol;
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -144,13 +144,13 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry, EntryFields } from "contentful";
                 
                 export interface TypeSysIdFields {
-                    boolFieldId?: Contentful.EntryFields.Boolean;
+                    boolFieldId?: EntryFields.Boolean;
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -181,14 +181,14 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 import { TypeLinkedTypeFields } from "./TypeLinkedType";
 
                 export interface TypeSysIdFields {
-                    linkFieldId?: Contentful.Entry<TypeLinkedTypeFields>;
+                    linkFieldId?: Entry<TypeLinkedTypeFields>;
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -223,15 +223,15 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 import { TypeArtistFields } from "./TypeArtist";
                 import { TypeArtworkFields } from "./TypeArtwork";
 
                 export interface TypeSysIdFields {
-                    arrayFieldId?: Contentful.Entry<TypeArtistFields | TypeArtworkFields>[];
+                    arrayFieldId?: Entry<TypeArtistFields | TypeArtworkFields>[];
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -261,13 +261,13 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
 
                 export interface TypeSysIdFields {
                     stringFieldId?: "hello" | "world";
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -297,13 +297,13 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                     numericFieldId?: 1 | 2 | 3;
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -317,12 +317,12 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
   });
@@ -345,23 +345,23 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result1.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
 
     expect('\n' + result2.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 
                 export interface TypeMyTypeFields {
                 }
 
-                export type TypeMyType = Contentful.Entry<TypeMyTypeFields>;
+                export type TypeMyType = Entry<TypeMyTypeFields>;
                 `),
     );
   });
@@ -400,25 +400,25 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result1.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                 }
 
-                export type TypeSysId = Contentful.Entry<TypeSysIdFields>;
+                export type TypeSysId = Entry<TypeSysIdFields>;
                 `),
     );
 
     expect('\n' + result2.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 import { TypeSysIdFields } from "./TypeSysId";
                 
                 export interface TypeMyTypeFields {
-                    linkFieldId?: Contentful.Entry<TypeSysIdFields>;
+                    linkFieldId?: Entry<TypeSysIdFields>;
                 }
 
-                export type TypeMyType = Contentful.Entry<TypeMyTypeFields>;
+                export type TypeMyType = Entry<TypeMyTypeFields>;
                 `),
     );
   });
@@ -468,13 +468,13 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result2.toString()).toEqual(
       stripIndent(`
-                import * as Contentful from "contentful";
+                import { Entry } from "contentful";
                 
                 export interface TypeMyTypeFields {
-                    linkFieldId?: Contentful.Entry<TypeMyTypeFields>;
+                    linkFieldId?: Entry<TypeMyTypeFields>;
                 }
 
-                export type TypeMyType = Contentful.Entry<TypeMyTypeFields>;
+                export type TypeMyType = Entry<TypeMyTypeFields>;
                 `),
     );
   });

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -49,7 +49,7 @@ describe('A Contentful definitions builder', () => {
     builder.appendType(modelType);
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
 
                 export interface TypeSysIdFields {
                 }
@@ -80,7 +80,7 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry, EntryFields } from "contentful";
+                import type { Entry, EntryFields } from "contentful";
                 
                 export interface TypeSysIdFields {
                     symbolFieldId: EntryFields.Symbol;
@@ -112,7 +112,7 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry, EntryFields } from "contentful";
+                import type { Entry, EntryFields } from "contentful";
                 
                 export interface TypeSysIdFields {
                     symbolFieldId?: EntryFields.Symbol;
@@ -144,7 +144,7 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry, EntryFields } from "contentful";
+                import type { Entry, EntryFields } from "contentful";
                 
                 export interface TypeSysIdFields {
                     boolFieldId?: EntryFields.Boolean;
@@ -181,8 +181,8 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
-                import { TypeLinkedTypeFields } from "./TypeLinkedType";
+                import type { Entry } from "contentful";
+                import type { TypeLinkedTypeFields } from "./TypeLinkedType";
 
                 export interface TypeSysIdFields {
                     linkFieldId?: Entry<TypeLinkedTypeFields>;
@@ -223,9 +223,9 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
-                import { TypeArtistFields } from "./TypeArtist";
-                import { TypeArtworkFields } from "./TypeArtwork";
+                import type { Entry } from "contentful";
+                import type { TypeArtistFields } from "./TypeArtist";
+                import type { TypeArtworkFields } from "./TypeArtwork";
 
                 export interface TypeSysIdFields {
                     arrayFieldId?: Entry<TypeArtistFields | TypeArtworkFields>[];
@@ -261,7 +261,7 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
 
                 export interface TypeSysIdFields {
                     stringFieldId?: "hello" | "world";
@@ -297,7 +297,7 @@ describe('A Contentful definitions builder', () => {
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                     numericFieldId?: 1 | 2 | 3;
@@ -317,7 +317,7 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                 }
@@ -345,7 +345,7 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result1.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                 }
@@ -356,7 +356,7 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result2.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
                 
                 export interface TypeMyTypeFields {
                 }
@@ -400,7 +400,7 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result1.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
                 
                 export interface TypeSysIdFields {
                 }
@@ -411,8 +411,8 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result2.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
-                import { TypeSysIdFields } from "./TypeSysId";
+                import type { Entry } from "contentful";
+                import type { TypeSysIdFields } from "./TypeSysId";
                 
                 export interface TypeMyTypeFields {
                     linkFieldId?: Entry<TypeSysIdFields>;
@@ -468,7 +468,7 @@ describe('A Contentful definitions builder', () => {
 
     expect('\n' + result2.toString()).toEqual(
       stripIndent(`
-                import { Entry } from "contentful";
+                import type { Entry } from "contentful";
                 
                 export interface TypeMyTypeFields {
                     linkFieldId?: Entry<TypeMyTypeFields>;

--- a/test/property-imports.test.ts
+++ b/test/property-imports.test.ts
@@ -26,6 +26,7 @@ describe('A typeImports function', () => {
       {
         moduleSpecifier: './TypeTopicCategory',
         namedImports: ['TypeTopicCategoryFields'],
+        isTypeOnly: true,
       },
     ]);
   });
@@ -64,6 +65,7 @@ describe('A typeImports function', () => {
       {
         moduleSpecifier: './TypeCategory',
         namedImports: ['TypeCategoryFields'],
+        isTypeOnly: true,
       },
     ]);
   });

--- a/test/renderer/field/render-prop-any.test.ts
+++ b/test/renderer/field/render-prop-any.test.ts
@@ -1,6 +1,12 @@
-import { renderPropAny } from '../../../src/renderer/field';
+import { createDefaultContext, RenderContext, renderPropAny } from '../../../src';
 
 describe('A renderPropAny function', () => {
+  let context: RenderContext;
+
+  beforeEach(() => {
+    context = createDefaultContext();
+  });
+
   it('can evaluate a "Symbol" type', () => {
     const field = JSON.parse(`
         {
@@ -16,7 +22,7 @@ describe('A renderPropAny function', () => {
         }
         `);
 
-    expect(renderPropAny(field)).toEqual('Contentful.EntryFields.Symbol');
+    expect(renderPropAny(field, context)).toEqual('EntryFields.Symbol');
   });
 
   it('can evaluate a "Symbol" type with "in" validation', () => {
@@ -40,7 +46,7 @@ describe('A renderPropAny function', () => {
         }
         `);
 
-    expect(renderPropAny(field)).toEqual('"Center-aligned" | "Left-aligned"');
+    expect(renderPropAny(field, context)).toEqual('"Center-aligned" | "Left-aligned"');
   });
 
   it('can evaluate a "Symbol" type with missing validations', () => {
@@ -56,6 +62,6 @@ describe('A renderPropAny function', () => {
       }
       `);
 
-    expect(renderPropAny(field)).toEqual('Contentful.EntryFields.Symbol');
+    expect(renderPropAny(field, context)).toEqual('EntryFields.Symbol');
   });
 });

--- a/test/renderer/field/render-prop-array.test.ts
+++ b/test/renderer/field/render-prop-array.test.ts
@@ -1,5 +1,4 @@
-import { renderPropArray } from '../../../src/renderer/field';
-import { createDefaultContext } from '../../../src/renderer/type';
+import { createDefaultContext, renderPropArray } from '../../../src';
 
 describe('A renderPropArray function', () => {
   it('can evaluate a "Array" of "Link" with no validations', () => {
@@ -21,9 +20,7 @@ describe('A renderPropArray function', () => {
       }
       `);
 
-    expect(renderPropArray(field, createDefaultContext())).toEqual(
-      'Contentful.Entry<Record<string, any>>[]',
-    );
+    expect(renderPropArray(field, createDefaultContext())).toEqual('Entry<Record<string, any>>[]');
   });
 
   it('can evaluate an "Array" of "Symbol"', () => {
@@ -46,9 +43,7 @@ describe('A renderPropArray function', () => {
         }
         `);
 
-    expect(renderPropArray(field, createDefaultContext())).toEqual(
-      'Contentful.EntryFields.Symbol[]',
-    );
+    expect(renderPropArray(field, createDefaultContext())).toEqual('EntryFields.Symbol[]');
   });
 
   it('can evaluate an "Array" of "Symbol" with "in" validation', () => {
@@ -114,7 +109,7 @@ describe('A renderPropArray function', () => {
         `);
 
     expect(renderPropArray(field, createDefaultContext())).toEqual(
-      'Contentful.Entry<TypeComponentCtaFields | TypeComponentFaqFields | TypeWrapperImageFields | TypeWrapperVideoFields>[]',
+      'Entry<TypeComponentCtaFields | TypeComponentFaqFields | TypeWrapperImageFields | TypeWrapperVideoFields>[]',
     );
   });
 });

--- a/test/renderer/field/render-prop-link.test.ts
+++ b/test/renderer/field/render-prop-link.test.ts
@@ -1,5 +1,4 @@
-import { renderPropLink } from '../../../src/renderer/field';
-import { createDefaultContext } from '../../../src/renderer/type';
+import { createDefaultContext, renderPropLink } from '../../../src';
 
 describe('A renderPropLink function', () => {
   it('can evaluate a "Link" type', () => {
@@ -23,9 +22,7 @@ describe('A renderPropLink function', () => {
         }
         `);
 
-    expect(renderPropLink(field, createDefaultContext())).toEqual(
-      'Contentful.Entry<TypeTopicCategoryFields>',
-    );
+    expect(renderPropLink(field, createDefaultContext())).toEqual('Entry<TypeTopicCategoryFields>');
   });
 
   it('can evaluate a "Link" type with no validations', () => {
@@ -43,8 +40,6 @@ describe('A renderPropLink function', () => {
       }
       `);
 
-    expect(renderPropLink(field, createDefaultContext())).toEqual(
-      'Contentful.Entry<Record<string, any>>',
-    );
+    expect(renderPropLink(field, createDefaultContext())).toEqual('Entry<Record<string, any>>');
   });
 });

--- a/test/renderer/field/render-prop-richtext.test.ts
+++ b/test/renderer/field/render-prop-richtext.test.ts
@@ -1,5 +1,4 @@
-import { renderRichText } from '../../../src/renderer/field';
-import { createDefaultContext } from '../../../src/renderer/type';
+import { createDefaultContext, renderRichText } from '../../../src';
 
 describe('A renderPropRichText function', () => {
   it('can evaluate a "RichText" type', () => {
@@ -25,6 +24,7 @@ describe('A renderPropRichText function', () => {
       {
         moduleSpecifier: '@contentful/rich-text-types',
         namespaceImport: 'CFRichTextTypes',
+        isTypeOnly: true,
       },
     ]);
   });

--- a/test/renderer/type/content-type-renfderer.test.ts
+++ b/test/renderer/type/content-type-renfderer.test.ts
@@ -75,7 +75,7 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import { Entry } from "contentful";
+        import type { Entry } from "contentful";
         
         export interface TypeTestFields {
             field_id: Test.Symbol;
@@ -137,8 +137,8 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import { EntryFields } from "contentful";
-        import { Entry } from "contentful";
+        import type { EntryFields } from "contentful";
+        import type { Entry } from "contentful";
         
         export interface TypeTestFields {
             /** Field of type "Symbol" */
@@ -157,6 +157,7 @@ describe('A derived content type renderer class', () => {
         context.imports.add({
           moduleSpecifier: '@custom',
           namedImports: ['IdScopedEntry'],
+          isTypeOnly: true,
         });
         return renderTypeGeneric(
           'IdScopedEntry',
@@ -191,8 +192,8 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import { EntryFields } from "contentful";
-        import { IdScopedEntry } from "@custom";
+        import type { EntryFields } from "contentful";
+        import type { IdScopedEntry } from "@custom";
         
         export interface TypeTestFields {
             field_id: EntryFields.Symbol;

--- a/test/renderer/type/content-type-renfderer.test.ts
+++ b/test/renderer/type/content-type-renfderer.test.ts
@@ -1,11 +1,16 @@
 import { Field, FieldType } from 'contentful';
 
 import { Project, ScriptTarget, SourceFile } from 'ts-morph';
-import { moduleFieldsName, moduleName } from '../../../src/module-name';
-import { defaultRenderers, FieldRenderer } from '../../../src/renderer/field';
-import { renderTypeGeneric } from '../../../src/renderer/generic';
-import { DefaultContentTypeRenderer, RenderContext } from '../../../src/renderer/type';
-import { CFContentType } from '../../../src/types';
+import {
+  CFContentType,
+  DefaultContentTypeRenderer,
+  defaultRenderers,
+  FieldRenderer,
+  moduleFieldsName,
+  moduleName,
+  RenderContext,
+  renderTypeGeneric,
+} from '../../../src';
 import stripIndent = require('strip-indent');
 
 describe('A derived content type renderer class', () => {
@@ -27,6 +32,7 @@ describe('A derived content type renderer class', () => {
     const symbolTypeRenderer = () => {
       return 'Test.Symbol';
     };
+
     class DerivedContentTypeRenderer extends DefaultContentTypeRenderer {
       public createContext(): RenderContext {
         return {
@@ -69,13 +75,13 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import * as Contentful from "contentful";
+        import { Entry } from "contentful";
         
         export interface TypeTestFields {
             field_id: Test.Symbol;
         }
         
-        export type TypeTest = Contentful.Entry<TypeTestFields>;
+        export type TypeTest = Entry<TypeTestFields>;
         `),
     );
   });
@@ -90,6 +96,7 @@ describe('A derived content type renderer class', () => {
           type: super.renderFieldType(field, context),
         };
       }
+
       protected renderEntry(contentType: CFContentType, context: RenderContext) {
         return {
           docs: [
@@ -130,15 +137,16 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import * as Contentful from "contentful";
+        import { EntryFields } from "contentful";
+        import { Entry } from "contentful";
         
         export interface TypeTestFields {
             /** Field of type "Symbol" */
-            field_id: Contentful.EntryFields.Symbol;
+            field_id: EntryFields.Symbol;
         }
         
         /** content type "display name" with id: test */
-        export type TypeTest = Contentful.Entry<TypeTestFields>;
+        export type TypeTest = Entry<TypeTestFields>;
         `),
     );
   });
@@ -183,11 +191,11 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import * as Contentful from "contentful";
+        import { EntryFields } from "contentful";
         import { IdScopedEntry } from "@custom";
         
         export interface TypeTestFields {
-            field_id: Contentful.EntryFields.Symbol;
+            field_id: EntryFields.Symbol;
         }
         
         export type TypeTest = IdScopedEntry<'test', TypeTestFields>;

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -54,8 +54,8 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import { EntryFields } from "contentful";
-        import { Entry } from "contentful";
+        import type { EntryFields } from "contentful";
+        import type { Entry } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -100,8 +100,8 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import { EntryFields } from "contentful";
-        import { Entry } from "contentful";
+        import type { EntryFields } from "contentful";
+        import type { Entry } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -143,8 +143,8 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import { EntryFields } from "contentful";
-        import { Entry } from "contentful";
+        import type { EntryFields } from "contentful";
+        import type { Entry } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -186,8 +186,8 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import { EntryFields } from "contentful";
-        import { Entry } from "contentful";
+        import type { EntryFields } from "contentful";
+        import type { Entry } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -237,8 +237,8 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import { EntryFields } from "contentful";
-        import { Entry } from "contentful";
+        import type { EntryFields } from "contentful";
+        import type { Entry } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'

--- a/test/renderer/type/localized-content-type-renfderer.test.ts
+++ b/test/renderer/type/localized-content-type-renfderer.test.ts
@@ -1,7 +1,6 @@
 import stripIndent = require('strip-indent');
 import { Project, ScriptTarget, SourceFile } from 'ts-morph';
-import { LocalizedContentTypeRenderer } from '../../../src/renderer/type';
-import { CFContentType } from '../../../src/types';
+import { CFContentType, LocalizedContentTypeRenderer } from '../../../src';
 
 describe('A localized content type renderer class', () => {
   let project: Project;
@@ -73,7 +72,7 @@ describe('A localized content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import { LocalizedFields, LocalizedEntry } from "./Localized";
+        import type { LocalizedFields, LocalizedEntry } from "./Localized";
         
         export type LocalizedTypeTestFields<Locales extends keyof any> = LocalizedFields<TypeTestFields, Locales>;
         export type LocalizedTypeTest<Locales extends keyof any> = LocalizedEntry<TypeTest, Locales>;


### PR DESCRIPTION
## Rework of type imports
- Switch to named imports for all types of `contentful` to ensure we only import type information.
- switch to type imports to aline with Typescript's latest defaults

Fixes https://github.com/contentful-userland/cf-content-types-generator/issues/163