### PR TITLE
feat: add new JSDoc renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,14 @@ If no custom renderers given, `CFDefinitionsBuilder` creates a `DefaultContentTy
 #### Example Usage
 
 ```typescript
-import { CFDefinitionsBuilder, DefaultContentTypeRenderer } from 'cf-content-types-generator';
+import { 
+  CFDefinitionsBuilder, 
+  DefaultContentTypeRenderer 
+} from 'cf-content-types-generator';
 
-const builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer(), new JsDocRenderer()]);
+const builder = new CFDefinitionsBuilder([
+  new DefaultContentTypeRenderer()
+]);
 ```
 
 ## LocalizedContentTypeRenderer
@@ -340,9 +345,15 @@ JSDocContentTypeRenderer can only render comments for already rendered types. It
 #### Example Usage
 
 ```typescript
-import { CFDefinitionsBuilder, JsDocRenderer } from 'cf-content-types-generator';
+import { 
+  CFDefinitionsBuilder, 
+  JsDocRenderer 
+} from 'cf-content-types-generator';
 
-const builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer(), new JsDocRenderer()]);
+const builder = new CFDefinitionsBuilder([
+  new DefaultContentTypeRenderer(), 
+  new JsDocRenderer()
+]);
 ```
 
 #### Example output

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Renderer](#renderer)
   - [Default Renderer](#DefaultContentTypeRenderer)
   - [Localized Renderer](#LocalizedContentTypeRenderer)
+  - [JSDoc Renderer](#JSDocContentTypeRenderer)
 - [Direct Usage](#direct-usage)
 - [Browser Usage](#browser-usage)
 
@@ -46,6 +47,7 @@ OPTIONS
   -o, --out=out                  output directory
   -p, --preserve                 preserve output folder
   -l, --localized                add localized types
+  -d, --jsdoc                    add JSDoc comments
   -s, --spaceId=spaceId          space id
   -t, --token=token              management token
   -v, --version                  show CLI version
@@ -235,7 +237,7 @@ Extend the default `BaseContentTypeRenderer` class, or implement the `ContentTyp
 Relevant methods to override:
 
 | Methods             | Description                                                                | Override                                                              |
-|---------------------|----------------------------------------------------------------------------|-----------------------------------------------------------------------|
+| ------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `render`            | Enriches a `SourceFile` with all relevant nodes                            | To control content type rendering (you should know what you're doing) |
 | `getContext`        | Returns new render context object                                          | To define custom type renderer and custom module name function        |
 | `addDefaultImports` | Define set of default imports added to every file                          | To control default imported modules                                   |
@@ -249,8 +251,8 @@ Relevant methods to override:
 Set content type renderers:
 
 ```typescript
-import CFDefinitionsBuilder from 'cf-content-types-generator';
 import {
+  CFDefinitionsBuilder,
   DefaultContentTypeRenderer,
   LocalizedContentTypeRenderer,
 } from 'cf-content-types-generator';
@@ -266,10 +268,33 @@ const builder = new CFDefinitionsBuilder([
 A renderer to render type fields and entry definitions. For most scenarios, this renderer is sufficient.
 If no custom renderers given, `CFDefinitionsBuilder` creates a `DefaultContentTypeRenderer` by default.
 
+#### Example Usage
+
+```typescript
+import { CFDefinitionsBuilder, DefaultContentTypeRenderer } from 'cf-content-types-generator';
+
+const builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer(), new JsDocRenderer()]);
+```
+
 ## LocalizedContentTypeRenderer
 
 Add additional types for localized fields. It adds utility types to transform fields into localized fields for given locales
 More details on the utility types can be found here: [Issue 121](https://github.com/contentful-userland/cf-content-types-generator/issues/121)
+
+#### Example Usage
+
+```typescript
+import {
+  CFDefinitionsBuilder,
+  DefaultContentTypeRenderer,
+  LocalizedContentTypeRenderer,
+} from 'cf-content-types-generator';
+
+const builder = new CFDefinitionsBuilder([
+  new DefaultContentTypeRenderer(),
+  new LocalizedContentTypeRenderer(),
+]);
+```
 
 #### Example output
 
@@ -293,7 +318,7 @@ export type LocalizedTypeCategory<Locales extends keyof any> = LocalizedEntry<
 >;
 ```
 
-#### Example usage
+#### Example output usage
 
 ```typescript
 const localizedCategory: LocalizedTypeCategory<'DE-de' | 'En-en'> = {
@@ -304,6 +329,42 @@ const localizedCategory: LocalizedTypeCategory<'DE-de' | 'En-en'> = {
     },
   },
 };
+```
+
+## JSDocContentTypeRenderer
+
+Adds [JSDoc](https://jsdoc.app/) Comments to every Entry type and Field type (created by the default renderer, or a renderer that creates the same entry and field type names). This renderer can be customized through [renderer options](src/renderer/type/js-doc-renderer.ts#L20).
+
+JSDocContentTypeRenderer can only render comments for already rendered types. It's essential to add it after the default renderer, or any renderer that creates entry and field types based on the context moduleName resolution.
+
+#### Example Usage
+
+```typescript
+import { CFDefinitionsBuilder, JsDocRenderer } from 'cf-content-types-generator';
+
+const builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer(), new JsDocRenderer()]);
+```
+
+#### Example output
+
+```typescript
+import * as Contentful from 'contentful';
+/**
+ * Fields type definition for content type 'TypeAnimalFields'
+ * @name TypeAnimalFields
+ * @type {TypeAnimalFields}
+ * @memberof TypeAnimal
+ */
+export interface TypeAnimalFields {
+  bread: Contentful.EntryFields.Symbol;
+}
+
+/**
+ * Entry type definition for content type 'animal' (Animal)
+ * @name TypeAnimal
+ * @type {TypeAnimal}
+ */
+export type TypeAnimal = Contentful.Entry<TypeAnimalFields>;
 ```
 
 # Direct Usage
@@ -329,20 +390,20 @@ const stringContent = new CFDefinitionsBuilder()
         validations: [],
         disabled: false,
         localized: false,
-        omitted: false
+        omitted: false,
       },
     ],
   })
   .toString();
 
-console.log(stringContent)
+console.log(stringContent);
 
 // import * as Contentful from "contentful";
-// 
+//
 // export interface TypeMyEntryFields {
 //   myField: Contentful.EntryFields.Symbol;
 // }
-// 
+//
 // export type TypeMyEntry = Contentful.Entry<TypeMyEntryFields>;
 ```
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@oclif/plugin-help": "^5.1.12",
     "contentful": "^9.1.29",
     "contentful-export": "^7.17.13",
+    "contentful-management": "^10.27.4",
     "fs-extra": "^10.1.0",
     "lodash": "^4.17.21",
     "ts-morph": "^17.0.1"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import CFDefinitionsBuilder from './cf-definitions-builder';
 import {
   ContentTypeRenderer,
   DefaultContentTypeRenderer,
+  JsDocRenderer,
   LocalizedContentTypeRenderer,
 } from './renderer/type';
 
@@ -20,6 +21,7 @@ class ContentfulMdg extends Command {
     out: flags.string({ char: 'o', description: 'output directory' }),
     preserve: flags.boolean({ char: 'p', description: 'preserve output folder' }),
     localized: flags.boolean({ char: 'l', description: 'add localized types' }),
+    jsdoc: flags.boolean({ char: 'd', description: 'add JSDoc comments' }),
 
     // remote access
     spaceId: flags.string({ char: 's', description: 'space id' }),
@@ -64,6 +66,10 @@ class ContentfulMdg extends Command {
     const renderers: ContentTypeRenderer[] = [new DefaultContentTypeRenderer()];
     if (flags.localized) {
       renderers.push(new LocalizedContentTypeRenderer());
+    }
+
+    if (flags.jsdoc) {
+      renderers.push(new JsDocRenderer());
     }
 
     const builder = new CFDefinitionsBuilder(renderers);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import CFDefinitionsBuilder from './cf-definitions-builder';
+
 export * from './extract-validation';
 export * from './module-name';
 export * from './property-imports';
 export * from './renderer';
 export * from './types';
 export default CFDefinitionsBuilder;
+export { CFDefinitionsBuilder };

--- a/src/renderer/type/index.ts
+++ b/src/renderer/type/index.ts
@@ -2,5 +2,6 @@ export { BaseContentTypeRenderer } from './base-content-type-renderer';
 export { ContentTypeRenderer } from './content-type-renderer';
 export { DefaultContentTypeRenderer } from './default-content-type-renderer';
 export { LocalizedContentTypeRenderer } from './localized-content-type-renderer';
+export { JsDocRenderer } from './js-doc-renderer';
 export { createDefaultContext } from './create-default-context';
 export type { RenderContext } from './create-default-context';

--- a/src/renderer/type/js-doc-renderer.ts
+++ b/src/renderer/type/js-doc-renderer.ts
@@ -1,0 +1,130 @@
+import { Field } from 'contentful';
+import { ContentTypeProps } from 'contentful-management';
+import { JSDocStructure, JSDocTagStructure, OptionalKind, SourceFile } from 'ts-morph';
+import { CFContentType } from '../../types';
+import { BaseContentTypeRenderer } from './base-content-type-renderer';
+
+type EntryDocsOptionsProps = {
+  /* Name of generated Entry type */
+  name: string;
+  readonly contentType: CFContentType;
+};
+
+type FieldsDocsOptionsProps = {
+  /* Name of generated Fields type */
+  name: string;
+  entryName: string;
+  readonly fields: Field[];
+};
+
+export type JSDocRenderOptions = {
+  renderEntryDocs?: (props: EntryDocsOptionsProps) => OptionalKind<JSDocStructure> | string;
+  renderFieldsDocs?: (props: FieldsDocsOptionsProps) => OptionalKind<JSDocStructure> | string;
+};
+
+export const defaultJsDocRenderOptions: Required<JSDocRenderOptions> = {
+  renderEntryDocs: ({ contentType, name }) => {
+    const tags: OptionalKind<JSDocTagStructure>[] = [];
+
+    tags.push(
+      {
+        tagName: 'name',
+        text: name,
+      },
+      {
+        tagName: 'type',
+        text: `{${name}}`,
+      },
+    );
+
+    const cmaContentType = contentType as ContentTypeProps;
+
+    if (cmaContentType.sys.createdBy?.sys?.id) {
+      tags.push({
+        tagName: 'author',
+        text: cmaContentType.sys.createdBy.sys.id,
+      });
+    }
+
+    if (cmaContentType.sys.firstPublishedAt) {
+      tags.push({
+        tagName: 'since',
+        text: cmaContentType.sys.firstPublishedAt,
+      });
+    }
+
+    if (cmaContentType.sys.publishedVersion) {
+      tags.push({
+        tagName: 'version',
+        text: cmaContentType.sys.publishedVersion.toString(),
+      });
+    }
+
+    return {
+      description: `Entry type definition for content type '${contentType.sys.id}' (${contentType.name})`,
+      tags,
+    };
+  },
+
+  renderFieldsDocs: ({ name, entryName }) => {
+    return {
+      description: `Fields type definition for content type '${name}'`,
+      tags: [
+        {
+          tagName: 'name',
+          text: name,
+        },
+        {
+          tagName: 'type',
+          text: `{${name}}`,
+        },
+        {
+          tagName: 'memberof',
+          text: entryName,
+        },
+      ],
+    };
+  },
+};
+
+/* JsDocRenderer only works in conjunction with other Renderers. It relays on previously rendered Interfaces */
+export class JsDocRenderer extends BaseContentTypeRenderer {
+  private renderOptions: Required<JSDocRenderOptions>;
+
+  constructor({ renderOptions }: { renderOptions?: JSDocRenderOptions } = {}) {
+    super();
+    this.renderOptions = {
+      ...defaultJsDocRenderOptions,
+      ...renderOptions,
+    };
+  }
+
+  public render = (contentType: CFContentType, file: SourceFile): void => {
+    const context = this.createContext();
+
+    const entryInterfaceName = context.moduleName(contentType.sys.id);
+    const entryInterface = file.getTypeAlias(entryInterfaceName);
+
+    if (entryInterface) {
+      entryInterface.addJsDoc(
+        this.renderOptions.renderEntryDocs({
+          name: entryInterfaceName,
+          contentType,
+        }),
+      );
+    }
+
+    const fieldsInterfaceName = context.moduleFieldsName(contentType.sys.id);
+    const fieldsInterface = file.getInterface(fieldsInterfaceName);
+
+    if (fieldsInterface) {
+      fieldsInterface.addJsDoc(
+        this.renderOptions.renderFieldsDocs({
+          name: fieldsInterfaceName,
+          entryName: entryInterfaceName,
+          fields: contentType.fields,
+        }),
+      );
+    }
+  };
+}

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -1,0 +1,234 @@
+import { Project, ScriptTarget, SourceFile } from 'ts-morph';
+import { CFContentType, DefaultContentTypeRenderer, JsDocRenderer } from '../../../src';
+import {
+  defaultJsDocRenderOptions,
+  JSDocRenderOptions,
+} from '../../../src/renderer/type/js-doc-renderer';
+import stripIndent = require('strip-indent');
+
+describe('A JSDoc content type renderer class', () => {
+  let project: Project;
+  let testFile: SourceFile;
+  let mockContentType: CFContentType;
+
+  beforeEach(() => {
+    project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        target: ScriptTarget.ES5,
+        declaration: true,
+      },
+    });
+
+    mockContentType = {
+      name: 'Animal',
+      sys: {
+        id: 'animal',
+        type: 'Symbol',
+      },
+      fields: [
+        {
+          id: 'bread',
+          name: 'Bread',
+          disabled: false,
+          localized: false,
+          required: true,
+          type: 'Symbol',
+          omitted: false,
+          validations: [],
+        },
+      ],
+    };
+
+    testFile = project.createSourceFile('test.ts');
+  });
+
+  describe('with default Entry Docs renderer', () => {
+    it('renders default JSDocs', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+      defaultRenderer.render(mockContentType, testFile);
+
+      const docsRenderer = new JsDocRenderer();
+      docsRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import * as Contentful from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimalFields'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            bread: Contentful.EntryFields.Symbol;
+        }
+        
+        /**
+         * Entry type definition for content type 'animal' (Animal)
+         * @name TypeAnimal
+         * @type {TypeAnimal}
+         */
+        export type TypeAnimal = Contentful.Entry<TypeAnimalFields>;
+        `),
+      );
+    });
+
+    it('renders optional Entry @author tag', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+
+      // @ts-ignore
+      mockContentType.sys.createdBy = {
+        sys: {
+          id: '<user-id>',
+        },
+      };
+
+      defaultRenderer.render(mockContentType, testFile);
+
+      const docsRenderer = new JsDocRenderer();
+      docsRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import * as Contentful from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimalFields'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            bread: Contentful.EntryFields.Symbol;
+        }
+        
+        /**
+         * Entry type definition for content type 'animal' (Animal)
+         * @name TypeAnimal
+         * @type {TypeAnimal}
+         * @author <user-id>
+         */
+        export type TypeAnimal = Contentful.Entry<TypeAnimalFields>;
+        `),
+      );
+    });
+
+    it('renders optional Entry @version tag', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+
+      // @ts-ignore
+      mockContentType.sys.publishedVersion = 5;
+
+      defaultRenderer.render(mockContentType, testFile);
+
+      const docsRenderer = new JsDocRenderer();
+      docsRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import * as Contentful from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimalFields'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            bread: Contentful.EntryFields.Symbol;
+        }
+        
+        /**
+         * Entry type definition for content type 'animal' (Animal)
+         * @name TypeAnimal
+         * @type {TypeAnimal}
+         * @version 5
+         */
+        export type TypeAnimal = Contentful.Entry<TypeAnimalFields>;
+        `),
+      );
+    });
+
+    it('renders optional Entry @since tag', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+
+      // @ts-ignore
+      mockContentType.sys.firstPublishedAt = '1675420727';
+
+      defaultRenderer.render(mockContentType, testFile);
+
+      const docsRenderer = new JsDocRenderer();
+      docsRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import * as Contentful from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimalFields'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            bread: Contentful.EntryFields.Symbol;
+        }
+        
+        /**
+         * Entry type definition for content type 'animal' (Animal)
+         * @name TypeAnimal
+         * @type {TypeAnimal}
+         * @since 1675420727
+         */
+        export type TypeAnimal = Contentful.Entry<TypeAnimalFields>;
+        `),
+      );
+    });
+  });
+
+  describe('with custom Entry Docs renderer', () => {
+    it('renders custom JSDoc for Entry type', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+
+      defaultRenderer.render(mockContentType, testFile);
+
+      const customRendererOptions: JSDocRenderOptions = {
+        renderFieldsDocs: defaultJsDocRenderOptions.renderFieldsDocs,
+        renderEntryDocs: () => {
+          return {
+            description: 'Custom entry description',
+          };
+        },
+      };
+
+      const docsRenderer = new JsDocRenderer({ renderOptions: customRendererOptions });
+      docsRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import * as Contentful from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimalFields'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            bread: Contentful.EntryFields.Symbol;
+        }
+        
+        /** Custom entry description */
+        export type TypeAnimal = Contentful.Entry<TypeAnimalFields>;
+        `),
+      );
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,6 +2686,18 @@ contentful-management@^10.0.0:
     fast-copy "^2.1.1"
     lodash.isplainobject "^4.0.6"
 
+contentful-management@^10.27.4:
+  version "10.27.4"
+  resolved "https://registry.yarnpkg.com/contentful-management/-/contentful-management-10.27.4.tgz#4414bd3dde0db91db85e3df6819829a687f68247"
+  integrity sha512-rHM2gedxHbvlAn1RXMGQm47uY33uxxjZADE+MGUseiVaPTEt9+EpoPyVKLTJc+eD8dH8x454oAYKjtK9xM11Ng==
+  dependencies:
+    "@types/json-patch" "0.0.30"
+    axios "^0.27.1"
+    contentful-sdk-core "^7.0.1"
+    fast-copy "^3.0.0"
+    lodash.isplainobject "^4.0.6"
+    type-fest "^3.0.0"
+
 contentful-resolve-response@^1.3.0:
   version "1.3.6"
   resolved "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.6.tgz"
@@ -3446,6 +3458,11 @@ fast-copy@^2.1.0, fast-copy@^2.1.1, fast-copy@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz"
   integrity sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g==
+
+fast-copy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.0.tgz#875ebf33b13948ae012b6e51d33da5e6e7571ab8"
+  integrity sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -7931,6 +7948,11 @@ type-fest@^1.0.2:
   version "1.4.0"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz"
   integrity sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==
+
+type-fest@^3.0.0:
+  version "3.5.4"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.4.tgz#9ba7d0556ebec5d26d55bb1c56d2f3f1d25746d4"
+  integrity sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA==
 
 typeable-promisify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Adds new JSDoc renderer to enrich types with JSDoc comments. 
When used "as code", the renderer can be fully configured through options. 

Can be used via CLI with flag `--jsdoc`