### PR TITLE
fix: type guard types in merge file [NONE]

### DIFF
--- a/src/renderer/type/type-guard-renderer.ts
+++ b/src/renderer/type/type-guard-renderer.ts
@@ -14,9 +14,13 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
 
   public override setup(project: Project): void {
     super.setup(project);
-    const file = project.createSourceFile(`TypeGuardTypes.ts`, undefined, {
-      overwrite: true,
-    });
+    const file = project.createSourceFile(
+      `${TypeGuardRenderer.WithContentTypeLink}.ts`,
+      undefined,
+      {
+        overwrite: true,
+      },
+    );
 
     file.addTypeAlias({
       name: TypeGuardRenderer.WithContentTypeLink,
@@ -31,7 +35,7 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
     const entryInterfaceName = moduleName(contentType.sys.id);
 
     file.addImportDeclaration({
-      moduleSpecifier: 'TypeGuardTypes',
+      moduleSpecifier: `./${TypeGuardRenderer.WithContentTypeLink}`,
       namedImports: [TypeGuardRenderer.WithContentTypeLink],
       isTypeOnly: true,
     });
@@ -55,4 +59,8 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
 
     file.formatText();
   };
+
+  public override additionalFiles(): SourceFile[] {
+    return this.files;
+  }
 }

--- a/test/renderer/type/type-guard-renderer.test.ts
+++ b/test/renderer/type/type-guard-renderer.test.ts
@@ -51,7 +51,7 @@ describe('A content type type guard renderer class', () => {
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
         import type { Entry, EntryFields } from "contentful";
-        import type { WithContentTypeLink } from "TypeGuardTypes";
+        import type { WithContentTypeLink } from "./WithContentTypeLink";
         
         export interface TypeAnimalFields {
             bread: EntryFields.Symbol;


### PR DESCRIPTION
`TypeGuardTypes`  were not properly presented in single file output