### PR TITLE
fix: exports of type guards

### DIFF
--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -163,13 +163,17 @@ export default class CFDefinitionsBuilder {
     for (const sourceFile of this.project.getSourceFiles()) {
       const exportDeclarations = sourceFile.getExportSymbols();
       if (sourceFile.getBaseNameWithoutExtension() !== 'index') {
-        indexFile.addExportDeclaration({
-          isTypeOnly: true,
-          namedExports: exportDeclarations.map((declaration) =>
-            declaration.getExportSymbol().getEscapedName(),
-          ),
-          moduleSpecifier: `./${sourceFile.getBaseNameWithoutExtension()}`,
-        });
+        // we have to add every single exported member to differentiate type only exports
+        // organize imports in the end optimize again and groups imports from same module
+        for (const exportDeclaration of exportDeclarations) {
+          indexFile.addExportDeclaration({
+            isTypeOnly: !sourceFile.getFunctions().some((f) => {
+              return f.getName() === exportDeclaration.getExportSymbol().getName();
+            }),
+            namedExports: [exportDeclaration.getExportSymbol().getEscapedName()],
+            moduleSpecifier: `./${sourceFile.getBaseNameWithoutExtension()}`,
+          });
+        }
       }
     }
 

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -584,4 +584,19 @@ describe('A Contentful definitions builder', () => {
           `),
     );
   });
+
+  it('can create index file with type guard functions', async () => {
+    builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer(), new TypeGuardRenderer()]);
+    builder.appendType(modelType);
+    await builder.write(fixturesPath, writeFile);
+
+    const result1 = await fs.readFile(path.resolve(fixturesPath, 'index.ts'));
+    expect('\n' + result1.toString()).toEqual(
+      stripIndent(`
+            export { isTypeSysId } from "./TypeSysId";
+            export type { TypeSysId, TypeSysIdFields } from "./TypeSysId";
+            export type { WithContentTypeLink } from "./WithContentTypeLink";
+            `),
+    );
+  });
 });


### PR DESCRIPTION
We can't export type guard functions as types. 

fixes https://github.com/contentful-userland/cf-content-types-generator/issues/237