### PR TITLE
feat: support resource link fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@oclif/config": "^1.18.3",
     "@oclif/errors": "^1.3.5",
     "@oclif/plugin-help": "^5.1.12",
-    "contentful": "^9.1.29",
+    "contentful": "^10.1.0",
     "contentful-export": "^7.17.13",
     "contentful-management": "^10.27.4",
     "fs-extra": "^11.1.0",

--- a/src/extract-validation.ts
+++ b/src/extract-validation.ts
@@ -1,8 +1,8 @@
-import { FieldItem, FieldValidation } from 'contentful';
+import { FieldItem, ContentTypeFieldValidation } from 'contentful';
 
 type WithValidations = Pick<FieldItem, 'validations'>;
 
-const validation = (node: WithValidations, field: keyof FieldValidation): any => {
+const validation = (node: WithValidations, field: keyof ContentTypeFieldValidation): any => {
   if (node.validations && node.validations.length > 0) {
     const linkContentValidation = node.validations.find((value) => value[field]);
     if (linkContentValidation) {

--- a/src/property-imports.ts
+++ b/src/property-imports.ts
@@ -1,10 +1,10 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
 import { linkContentTypeValidations } from './extract-validation';
 import { RenderContext } from './renderer';
 
 export const propertyImports = (
-  field: Field,
+  field: ContentTypeField,
   context: RenderContext,
   ignoreModule?: string,
 ): OptionalKind<ImportDeclarationStructure>[] => {

--- a/src/renderer/field/default-renderers.ts
+++ b/src/renderer/field/default-renderers.ts
@@ -1,12 +1,14 @@
 import { renderPropAny } from './render-prop-any';
 import { renderPropArray } from './render-prop-array';
 import { renderPropLink } from './render-prop-link';
+import { renderPropResourceLink } from './render-prop-resource-link';
 import { renderRichText } from './render-prop-richtext';
 import { FieldRenderers } from './render-types';
 
 export const defaultRenderers: FieldRenderers = {
   RichText: renderRichText,
   Link: renderPropLink,
+  ResourceLink: renderPropResourceLink,
   Array: renderPropArray,
   Text: renderPropAny,
   Symbol: renderPropAny,

--- a/src/renderer/field/index.ts
+++ b/src/renderer/field/index.ts
@@ -2,5 +2,6 @@ export * from './render-types';
 export { renderPropAny } from './render-prop-any';
 export { renderPropArray } from './render-prop-array';
 export { renderPropLink } from './render-prop-link';
+export { renderPropResourceLink } from './render-prop-resource-link';
 export { renderRichText } from './render-prop-richtext';
 export { defaultRenderers } from './default-renderers';

--- a/src/renderer/field/render-prop-any.ts
+++ b/src/renderer/field/render-prop-any.ts
@@ -1,8 +1,8 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import { renderTypeLiteral, renderTypeUnion } from '../generic';
 import { RenderContext } from '../type';
 
-export const renderPropAny = (field: Field, context: RenderContext): string => {
+export const renderPropAny = (field: ContentTypeField, context: RenderContext): string => {
   if (field.validations?.length > 0) {
     const includesValidation = field.validations.find((validation) => validation.in);
     if (includesValidation && includesValidation.in) {

--- a/src/renderer/field/render-prop-array.ts
+++ b/src/renderer/field/render-prop-array.ts
@@ -1,15 +1,19 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import { inValidations } from '../../extract-validation';
 import { renderTypeArray, renderTypeLiteral, renderTypeUnion } from '../generic';
 import { RenderContext } from '../type';
 
-export const renderPropArray = (field: Field, context: RenderContext): string => {
+export const renderPropArray = (field: ContentTypeField, context: RenderContext): string => {
   if (!field.items) {
     throw new Error(`missing items for ${field.id}`);
   }
 
   if (field.items.type === 'Link') {
     return renderTypeArray(context.getFieldRenderer('Link')(field.items, context));
+  }
+
+  if (field.items.type === 'ResourceLink') {
+    return renderTypeArray(context.getFieldRenderer('ResourceLink')(field, context));
   }
 
   if (field.items.type === 'Symbol') {

--- a/src/renderer/field/render-prop-link.ts
+++ b/src/renderer/field/render-prop-link.ts
@@ -1,13 +1,16 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import { linkContentTypeValidations } from '../../extract-validation';
 import { renderTypeGeneric, renderTypeUnion } from '../generic';
 import { RenderContext } from '../type';
 
 export const renderPropLink = (
-  field: Pick<Field, 'validations' | 'linkType'>,
+  field: Pick<ContentTypeField, 'validations' | 'linkType'>,
   context: RenderContext,
 ): string => {
-  const linkContentType = (field: Pick<Field, 'validations'>, context: RenderContext): string => {
+  const linkContentType = (
+    field: Pick<ContentTypeField, 'validations'>,
+    context: RenderContext,
+  ): string => {
     const validations = linkContentTypeValidations(field);
     return validations?.length > 0
       ? renderTypeUnion(validations.map((validation) => context.moduleFieldsName(validation)))

--- a/src/renderer/field/render-prop-resource-link.ts
+++ b/src/renderer/field/render-prop-resource-link.ts
@@ -1,0 +1,19 @@
+import { ContentTypeField } from 'contentful';
+import { renderTypeGeneric } from '../generic';
+import { RenderContext } from '../type';
+
+export const renderPropResourceLink = (field: ContentTypeField, context: RenderContext): string => {
+  for (const resource of field.allowedResources!) {
+    if (resource.type !== 'Contentful:Entry') {
+      throw new Error(`Unknown type "${resource.type}"`);
+    }
+  }
+
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['Entry'],
+    isTypeOnly: true,
+  });
+
+  return renderTypeGeneric('Entry', 'Record<string, any>');
+};

--- a/src/renderer/field/render-prop-richtext.ts
+++ b/src/renderer/field/render-prop-richtext.ts
@@ -1,7 +1,7 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import { RenderContext } from '../type';
 
-export const renderRichText = (field: Field, context: RenderContext): string => {
+export const renderRichText = (field: ContentTypeField, context: RenderContext): string => {
   context.imports.add({
     moduleSpecifier: 'contentful',
     namedImports: ['EntryFields'],

--- a/src/renderer/field/render-types.ts
+++ b/src/renderer/field/render-types.ts
@@ -1,14 +1,17 @@
-import { Field, FieldType } from 'contentful';
+import { ContentTypeField, ContentTypeFieldType } from 'contentful';
 import { RenderContext } from '../type';
 
-export type FieldRenderer<FType extends FieldType> = (
-  field: FType extends 'Link' ? Pick<Field, 'validations' | 'linkType'> : Field,
+export type FieldRenderer<FType extends ContentTypeFieldType> = (
+  field: FType extends 'Link'
+    ? Pick<ContentTypeField, 'validations' | 'linkType'>
+    : ContentTypeField,
   context: RenderContext,
 ) => string;
 
 export type FieldRenderers = {
   RichText: FieldRenderer<'RichText'>;
   Link: FieldRenderer<'Link'>;
+  ResourceLink: FieldRenderer<'ResourceLink'>;
   Array: FieldRenderer<'Array'>;
   Text: FieldRenderer<'Text'>;
   Symbol: FieldRenderer<'Symbol'>;

--- a/src/renderer/type/create-default-context.ts
+++ b/src/renderer/type/create-default-context.ts
@@ -1,10 +1,10 @@
-import { FieldType } from 'contentful';
+import { ContentTypeFieldType } from 'contentful';
 import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
 import { moduleFieldsName, moduleName } from '../../module-name';
 import { defaultRenderers, FieldRenderer } from '../field';
 
 export type RenderContext = {
-  getFieldRenderer: <FType extends FieldType>(fieldType: FType) => FieldRenderer<FType>;
+  getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;
   moduleName: (id: string) => string;
   moduleFieldsName: (id: string) => string;
   imports: Set<OptionalKind<ImportDeclarationStructure>>;
@@ -14,7 +14,7 @@ export const createDefaultContext = (): RenderContext => {
   return {
     moduleName,
     moduleFieldsName,
-    getFieldRenderer: <FType extends FieldType>(fieldType: FType) =>
+    getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) =>
       defaultRenderers[fieldType] as FieldRenderer<FType>,
     imports: new Set(),
   };

--- a/src/renderer/type/default-content-type-renderer.ts
+++ b/src/renderer/type/default-content-type-renderer.ts
@@ -1,4 +1,4 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import {
   OptionalKind,
   PropertySignatureStructure,
@@ -48,7 +48,7 @@ export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
   protected addDefaultImports(context: RenderContext): void {}
 
   protected renderField(
-    field: Field,
+    field: ContentTypeField,
     context: RenderContext,
   ): OptionalKind<PropertySignatureStructure> {
     return {
@@ -58,7 +58,7 @@ export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
     };
   }
 
-  protected renderFieldType(field: Field, context: RenderContext): string {
+  protected renderFieldType(field: ContentTypeField, context: RenderContext): string {
     return context.getFieldRenderer(field.type)(field, context);
   }
 

--- a/src/renderer/type/js-doc-renderer.ts
+++ b/src/renderer/type/js-doc-renderer.ts
@@ -1,4 +1,4 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 import { ContentTypeProps } from 'contentful-management';
 import { JSDocStructure, JSDocTagStructure, OptionalKind, SourceFile } from 'ts-morph';
 import { CFContentType } from '../../types';
@@ -14,11 +14,11 @@ type FieldsDocsOptionsProps = {
   /* Name of generated Fields type */
   readonly name: string;
   readonly entryName: string;
-  readonly fields: Field[];
+  readonly fields: ContentTypeField[];
 };
 
 type FieldDocsOptionsProps = {
-  readonly field: Field;
+  readonly field: ContentTypeField;
 };
 
 export type JSDocRenderOptions = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { Field } from 'contentful';
+import { ContentTypeField } from 'contentful';
 
 export type WriteCallback = (filePath: string, content: string) => Promise<void>;
 
@@ -8,5 +8,5 @@ export type CFContentType = {
     id: string;
     type: string;
   };
-  fields: Field[];
+  fields: ContentTypeField[];
 };

--- a/test/renderer/field/render-prop-array.test.ts
+++ b/test/renderer/field/render-prop-array.test.ts
@@ -112,4 +112,37 @@ describe('A renderPropArray function', () => {
       'Entry<TypeComponentCtaFields | TypeComponentFaqFields | TypeWrapperImageFields | TypeWrapperVideoFields>[]',
     );
   });
+
+  it('can evaluate a "Array" of "ResourceLink"', () => {
+    const field = JSON.parse(`
+      {
+        "id": "components",
+        "name": "Components",
+        "type": "Array",
+        "localized": false,
+        "required": true,
+        "validations": [],
+        "disabled": false,
+        "omitted": false,
+        "items": {
+          "type": "ResourceLink",
+          "validations": []
+        },
+        "allowedResources": [
+          {
+            "type": "Contentful:Entry",
+            "source": "crn:contentful:::content:spaces/spaceId",
+            "contentTypes": [
+              "componentCta",
+              "componentFaq",
+              "wrapperImage",
+              "wrapperVideo"
+            ]
+          }
+        ]
+      }
+    `);
+
+    expect(renderPropArray(field, createDefaultContext())).toEqual('Entry<Record<string, any>>[]');
+  });
 });

--- a/test/renderer/field/render-prop-resource-link.test.ts
+++ b/test/renderer/field/render-prop-resource-link.test.ts
@@ -1,0 +1,59 @@
+import { createDefaultContext, renderPropResourceLink } from '../../../src';
+
+describe('A renderPropResourceLink function', () => {
+  it('can evaluate a "ResourceLink" type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "ResourceLink",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "allowedResources": [
+            {
+              "type": "Contentful:Entry",
+              "source": "crn:contentful:::content:spaces/spaceId",
+                "contentTypes": [
+                "topicCategory"
+              ]
+            }
+          ]
+         }
+        `);
+
+    expect(renderPropResourceLink(field, createDefaultContext())).toEqual(
+      'Entry<Record<string, any>>',
+    );
+  });
+
+  it('rejects a "ResourceLink" with an unknown resource type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "ResourceLink",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "allowedResources": [
+            {
+              "type": "Contentful:UnknownEntity",
+              "source": "crn:contentful:::content:spaces/spaceId",
+                "contentTypes": [
+                "topicCategory"
+              ]
+            }
+          ]
+         }
+      `);
+
+    expect(() => renderPropResourceLink(field, createDefaultContext())).toThrow(
+      'Unknown type "Contentful:UnknownEntity"',
+    );
+  });
+});

--- a/test/renderer/type/content-type-renfderer.test.ts
+++ b/test/renderer/type/content-type-renfderer.test.ts
@@ -1,4 +1,4 @@
-import { Field, FieldType } from 'contentful';
+import { ContentTypeField, ContentTypeFieldType } from 'contentful';
 
 import { Project, ScriptTarget, SourceFile } from 'ts-morph';
 import {
@@ -38,7 +38,7 @@ describe('A derived content type renderer class', () => {
         return {
           moduleName,
           moduleFieldsName,
-          getFieldRenderer: <FType extends FieldType>(fieldType: FType) => {
+          getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => {
             if (fieldType === 'Symbol') {
               return symbolTypeRenderer as FieldRenderer<FType>;
             }
@@ -88,7 +88,7 @@ describe('A derived content type renderer class', () => {
 
   it('can return a custom field renderer with docs support', () => {
     class DerivedContentTypeRenderer extends DefaultContentTypeRenderer {
-      protected renderField(field: Field, context: RenderContext) {
+      protected renderField(field: ContentTypeField, context: RenderContext) {
         return {
           docs: [{ description: `Field of type "${field.type}"` }],
           name: field.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,6 +319,11 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@contentful/rich-text-types@^16.0.2":
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.0.3.tgz#c590268483e07881fb01b6799e837337093e42bf"
+  integrity sha512-BsUtXj93jo5XUt0YeUwfCkMWRoZIzJDPUIY4vMy9SwGIO9olTsMoQKadjA2ktlmK+Gg6710WH3eFKZxj2q39Iw==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
@@ -1947,6 +1952,13 @@ aws-sdk@^2.1231.0:
     uuid "8.0.0"
     xml2js "0.4.19"
 
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 axios@^0.27.0, axios@^0.27.1:
   version "0.27.2"
   resolved "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz"
@@ -2705,6 +2717,13 @@ contentful-resolve-response@^1.3.0:
   dependencies:
     fast-copy "^2.1.3"
 
+contentful-resolve-response@^1.3.6:
+  version "1.6.5"
+  resolved "https://registry.yarnpkg.com/contentful-resolve-response/-/contentful-resolve-response-1.6.5.tgz#856eb29049e1f48293b1df2c5e6fbaa450bffce7"
+  integrity sha512-3uH6tI8rmBnDDtzyD4fZg3aecuYYCMe0q24/sdgQELvsza+OAiqrxzyiXJIAs7c5exIp5bbLwMtZLW/33OGvxg==
+  dependencies:
+    fast-copy "^2.1.7"
+
 contentful-sdk-core@^7.0.1:
   version "7.0.2"
   resolved "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.2.tgz"
@@ -2716,7 +2735,30 @@ contentful-sdk-core@^7.0.1:
     p-throttle "^4.1.1"
     qs "^6.9.4"
 
-contentful@^9.0.0, contentful@^9.1.29:
+contentful-sdk-core@^7.0.2:
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-7.0.6.tgz#bd6be54f166b5cddf7a5132f8087b22d8bb8d477"
+  integrity sha512-xG4+a4p7VGCuxxUWh8t3O3V6gEcPP/aSE/KkvPRMYkm8PbxWYTAYG3c5pn5lmtj1QKcsY7yjiLWRXtP4qzem3Q==
+  dependencies:
+    fast-copy "^2.1.7"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    p-throttle "^4.1.1"
+    qs "^6.9.4"
+
+contentful@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.1.0.tgz#a030524826c070985d01fba5f10c1be4f298d2b4"
+  integrity sha512-5xhzPQhCirZ0PoC4YFPC4NTKWjf9TU4iricvf/ETWiHiHROQYPm2NdPrHz55IZ7AHH6kvqUeGDEtmxz+Idg2gw==
+  dependencies:
+    "@contentful/rich-text-types" "^16.0.2"
+    axios "^0.26.1"
+    contentful-resolve-response "^1.3.6"
+    contentful-sdk-core "^7.0.2"
+    json-stringify-safe "^5.0.1"
+    type-fest "^3.1.0"
+
+contentful@^9.0.0:
   version "9.1.29"
   resolved "https://registry.npmjs.org/contentful/-/contentful-9.1.29.tgz"
   integrity sha512-yt9ER56n6xRDWYz+fzYxXxls7dNpCLnsD0Walov2eJ/24CRAO9D+lP1KQEkiYZI1uXSYuzEwokj+AcFvU3HpRQ==
@@ -3459,6 +3501,11 @@ fast-copy@^2.1.0, fast-copy@^2.1.3:
   resolved "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.3.tgz"
   integrity sha512-LDzYKNTHhD+XOp8wGMuCkY4eTxFZOOycmpwLBiuF3r3OjOmZnURRD8t2dUAbmKuXGbo/MGggwbSjcBdp8QT0+g==
 
+fast-copy@^2.1.7:
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-2.1.7.tgz#affc9475cb4b555fb488572b2a44231d0c9fa39e"
+  integrity sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA==
+
 fast-copy@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.0.tgz#875ebf33b13948ae012b6e51d33da5e6e7571ab8"
@@ -3634,6 +3681,11 @@ flatted@^3.1.0:
   version "3.2.5"
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
+
+follow-redirects@^1.14.8:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 follow-redirects@^1.14.9:
   version "1.15.1"
@@ -7957,6 +8009,11 @@ type-fest@^3.0.0:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.5.4.tgz#9ba7d0556ebec5d26d55bb1c56d2f3f1d25746d4"
   integrity sha512-/Je22Er4LPoln256pcLzj73MUmPrTWg8u4WB1RlxaDl0idJOfD1r259VtKOinp4xLJqJ9zYVMuWOun6Ssp7boA==
+
+type-fest@^3.1.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.8.0.tgz#ce80d1ca7c7d11c5540560999cbd410cb5b3a385"
+  integrity sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==
 
 typeable-promisify@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Add basic support for `ResourceLink` fields to address https://github.com/contentful-userland/cf-content-types-generator/issues/198 and update contentful.js to v10 because resource link support in v9 is slightly broken.

This version doesn’t add types for content types linked in `ResourceLink` fields as that would require a bigger change to fetch content types from multiple spaces.