### PR TITLE
feat: add support for contentful.js v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,10 +279,21 @@ import { CFDefinitionsBuilder, DefaultContentTypeRenderer } from 'cf-content-typ
 const builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer()]);
 ```
 
+## V10ContentTypeRenderer
+
+A renderer to render type fields and entry definitions compatible with contentful.js v10.
+
+```typescript
+import { CFDefinitionsBuilder, V10ContentTypeRenderer } from 'cf-content-types-generator';
+
+const builder = new CFDefinitionsBuilder([new V10ContentTypeRenderer()]);
+```
+
 ## LocalizedContentTypeRenderer
 
 Add additional types for localized fields. It adds utility types to transform fields into localized fields for given locales
 More details on the utility types can be found here: [Issue 121](https://github.com/contentful-userland/cf-content-types-generator/issues/121)
+Note that these types are not needed when using `V10ContentTypeRenderer` as the v10 entry type already supports localization.
 
 #### Example Usage
 
@@ -382,7 +393,7 @@ Adds type guard functions for every content type
 #### Example Usage
 
 ```typescript
-import { CFDefinitionsBuilder, TypeGuardRenderer } from 'cf-content-types-generator';
+import { CFDefinitionsBuilder, DefaultContentTypeRenderer, TypeGuardRenderer } from 'cf-content-types-generator';
 
 const builder = new CFDefinitionsBuilder([
   new DefaultContentTypeRenderer(),
@@ -404,6 +415,38 @@ export type TypeAnimal = Entry<TypeAnimalFields>;
 
 export function isTypeAnimal(entry: WithContentTypeLink): entry is TypeAnimal {
   return entry.sys.contentType.sys.id === 'animal';
+}
+```
+
+## V10TypeGuardRenderer
+
+Adds type guard functions for every content type which are compatible with contentful.js v10.
+
+#### Example Usage
+
+```typescript
+import { CFDefinitionsBuilder, V10ContentTypeRenderer, V10TypeGuardRenderer } from 'cf-content-types-generator';
+
+const builder = new CFDefinitionsBuilder([
+  new V10ContentTypeRenderer(),
+  new V10TypeGuardRenderer(),
+]);
+```
+
+#### Example output
+
+```typescript
+import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
+
+export interface TypeAnimalFields {
+  bread?: EntryFieldTypes.Symbol;
+}
+
+export type TypeAnimalSkeleton = EntrySkeletonType<TypeAnimalFields, "animal">;
+export type TypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeAnimalSkeleton, Modifiers, Locales>;
+
+export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
+  return entry.sys.contentType.sys.id === 'animal'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ OPTIONS
   -h, --help                     show CLI help
   -o, --out=out                  output directory
   -p, --preserve                 preserve output folder
+  -X  --v10                      create contentful.js v10 types
   -l, --localized                add localized types
   -d, --jsdoc                    add JSDoc comments
   -g, --typeguard                add type guards

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,10 +6,12 @@ import CFDefinitionsBuilder from './cf-definitions-builder';
 import {
   ContentTypeRenderer,
   DefaultContentTypeRenderer,
+  V10ContentTypeRenderer,
   JsDocRenderer,
   LocalizedContentTypeRenderer,
   TypeGuardRenderer,
 } from './renderer';
+import { V10TypeGuardRenderer } from './renderer/type/v10-type-guard-renderer';
 
 // eslint-disable-next-line unicorn/prefer-module
 const contentfulExport = require('contentful-export');
@@ -21,6 +23,7 @@ class ContentfulMdg extends Command {
     help: flags.help({ char: 'h' }),
     out: flags.string({ char: 'o', description: 'output directory' }),
     preserve: flags.boolean({ char: 'p', description: 'preserve output folder' }),
+    v10: flags.boolean({ char: 'X', description: 'create contentful.js v10 types' }),
     localized: flags.boolean({ char: 'l', description: 'add localized types' }),
     jsdoc: flags.boolean({ char: 'd', description: 'add JSDoc comments' }),
     typeguard: flags.boolean({ char: 'g', description: 'add type guards' }),
@@ -65,7 +68,9 @@ class ContentfulMdg extends Command {
       });
     }
 
-    const renderers: ContentTypeRenderer[] = [new DefaultContentTypeRenderer()];
+    const renderers: ContentTypeRenderer[] = flags.v10
+      ? [new V10ContentTypeRenderer()]
+      : [new DefaultContentTypeRenderer()];
     if (flags.localized) {
       renderers.push(new LocalizedContentTypeRenderer());
     }
@@ -75,7 +80,7 @@ class ContentfulMdg extends Command {
     }
 
     if (flags.typeguard) {
-      renderers.push(new TypeGuardRenderer());
+      renderers.push(flags.v10 ? new V10TypeGuardRenderer() : new TypeGuardRenderer());
     }
 
     const builder = new CFDefinitionsBuilder(renderers);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,6 +72,12 @@ class ContentfulMdg extends Command {
       ? [new V10ContentTypeRenderer()]
       : [new DefaultContentTypeRenderer()];
     if (flags.localized) {
+      if (flags.v10) {
+        this.error(
+          '"--localized" option is not needed, contentful.js v10 types have localization built in.',
+        );
+      }
+
       renderers.push(new LocalizedContentTypeRenderer());
     }
 

--- a/src/module-name.ts
+++ b/src/module-name.ts
@@ -9,6 +9,10 @@ export const moduleName = (name: string): string => {
   return pipe([replaceDash, upperFirst, addPrefix, removeSpace])(name);
 };
 
+export const moduleSkeletonName = (name: string): string => {
+  return moduleName(name) + 'Skeleton';
+};
+
 export const moduleFieldsName = (name: string): string => {
   return moduleName(name) + 'Fields';
 };

--- a/src/renderer/field/index.ts
+++ b/src/renderer/field/index.ts
@@ -1,7 +1,7 @@
 export * from './render-types';
-export { renderPropAny } from './render-prop-any';
-export { renderPropArray } from './render-prop-array';
-export { renderPropLink } from './render-prop-link';
-export { renderPropResourceLink } from './render-prop-resource-link';
-export { renderRichText } from './render-prop-richtext';
+export { renderPropAny, renderPropAnyV10 } from './render-prop-any';
+export { renderPropArray, renderPropArrayV10 } from './render-prop-array';
+export { renderPropLink, renderPropLinkV10 } from './render-prop-link';
+export { renderPropResourceLink, renderPropResourceLinkV10 } from './render-prop-resource-link';
+export { renderRichText, renderRichTextV10 } from './render-prop-richtext';
 export { defaultRenderers } from './default-renderers';

--- a/src/renderer/field/index.ts
+++ b/src/renderer/field/index.ts
@@ -5,3 +5,4 @@ export { renderPropLink, renderPropLinkV10 } from './render-prop-link';
 export { renderPropResourceLink, renderPropResourceLinkV10 } from './render-prop-resource-link';
 export { renderRichText, renderRichTextV10 } from './render-prop-richtext';
 export { defaultRenderers } from './default-renderers';
+export { v10Renderers } from './v10-renderers';

--- a/src/renderer/field/render-prop-any.ts
+++ b/src/renderer/field/render-prop-any.ts
@@ -1,5 +1,5 @@
 import { ContentTypeField } from 'contentful';
-import { renderTypeLiteral, renderTypeUnion } from '../generic';
+import { renderTypeGeneric, renderTypeLiteral, renderTypeUnion } from '../generic';
 import { RenderContext } from '../type';
 
 export const renderPropAny = (field: ContentTypeField, context: RenderContext): string => {
@@ -25,4 +25,32 @@ export const renderPropAny = (field: ContentTypeField, context: RenderContext): 
   });
 
   return `EntryFields.${field.type}`;
+};
+
+export const renderPropAnyV10 = (field: ContentTypeField, context: RenderContext): string => {
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['EntryFieldTypes'],
+    isTypeOnly: true,
+  });
+
+  if (field.validations?.length > 0) {
+    const includesValidation = field.validations.find((validation) => validation.in);
+    if (includesValidation && includesValidation.in) {
+      const mapper = (): ((value: string) => string) => {
+        if (field.type === 'Symbol' || field.type === 'Text' || field.type === 'RichText') {
+          return renderTypeLiteral;
+        }
+
+        return (value: string) => value.toString();
+      };
+
+      return renderTypeGeneric(
+        `EntryFieldTypes.${field.type}`,
+        renderTypeUnion(includesValidation.in.map((type) => mapper()(type))),
+      );
+    }
+  }
+
+  return `EntryFieldTypes.${field.type}`;
 };

--- a/src/renderer/field/render-prop-array.ts
+++ b/src/renderer/field/render-prop-array.ts
@@ -1,6 +1,6 @@
 import { ContentTypeField } from 'contentful';
 import { inValidations } from '../../extract-validation';
-import { renderTypeArray, renderTypeLiteral, renderTypeUnion } from '../generic';
+import { renderTypeArray, renderTypeGeneric, renderTypeLiteral, renderTypeUnion } from '../generic';
 import { RenderContext } from '../type';
 
 export const renderPropArray = (field: ContentTypeField, context: RenderContext): string => {
@@ -36,6 +36,49 @@ export const renderPropArray = (field: ContentTypeField, context: RenderContext)
     });
 
     return renderTypeArray('EntryFields.Symbol');
+  }
+
+  throw new Error('unhandled array type "' + field.items.type + '"');
+};
+
+export const renderPropArrayV10 = (field: ContentTypeField, context: RenderContext): string => {
+  if (!field.items) {
+    throw new Error(`missing items for ${field.id}`);
+  }
+
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['EntryFieldTypes'],
+    isTypeOnly: true,
+  });
+
+  if (field.items.type === 'Link') {
+    return renderTypeGeneric(
+      'EntryFieldTypes.Array',
+      context.getFieldRenderer('Link')(field.items, context),
+    );
+  }
+
+  if (field.items.type === 'ResourceLink') {
+    return renderTypeGeneric(
+      'EntryFieldTypes.Array',
+      context.getFieldRenderer('ResourceLink')(field, context),
+    );
+  }
+
+  if (field.items.type === 'Symbol') {
+    const validation = inValidations(field.items);
+
+    if (validation?.length > 0) {
+      const validationsTypes = validation.map((val: string) => renderTypeLiteral(val));
+
+      return renderTypeGeneric(
+        'EntryFieldTypes.Array',
+        renderTypeGeneric('EntryFieldTypes.Symbol', renderTypeUnion(validationsTypes)),
+      );
+    }
+
+    return renderTypeGeneric('EntryFieldTypes.Array', 'EntryFieldTypes.Symbol');
   }
 
   throw new Error('unhandled array type "' + field.items.type + '"');

--- a/src/renderer/field/render-prop-link.ts
+++ b/src/renderer/field/render-prop-link.ts
@@ -38,3 +38,35 @@ export const renderPropLink = (
       throw new Error(`Unknown linkType "${field.linkType}"`);
   }
 };
+
+export const renderPropLinkV10 = (
+  field: Pick<ContentTypeField, 'validations' | 'linkType'>,
+  context: RenderContext,
+): string => {
+  const linkContentType = (
+    field: Pick<ContentTypeField, 'validations'>,
+    context: RenderContext,
+  ): string => {
+    const validations = linkContentTypeValidations(field);
+    return validations?.length > 0
+      ? renderTypeUnion(validations.map((validation) => context.moduleSkeletonName(validation)))
+      : 'EntrySkeletonType';
+  };
+
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['EntryFieldTypes'],
+    isTypeOnly: true,
+  });
+
+  switch (field.linkType) {
+    case 'Entry':
+      return renderTypeGeneric('EntryFieldTypes.EntryLink', linkContentType(field, context));
+
+    case 'Asset':
+      return 'EntryFieldTypes.AssetLink';
+
+    default:
+      throw new Error(`Unknown linkType "${field.linkType}"`);
+  }
+};

--- a/src/renderer/field/render-prop-resource-link.ts
+++ b/src/renderer/field/render-prop-resource-link.ts
@@ -17,3 +17,22 @@ export const renderPropResourceLink = (field: ContentTypeField, context: RenderC
 
   return renderTypeGeneric('Entry', 'Record<string, any>');
 };
+
+export const renderPropResourceLinkV10 = (
+  field: ContentTypeField,
+  context: RenderContext,
+): string => {
+  for (const resource of field.allowedResources!) {
+    if (resource.type !== 'Contentful:Entry') {
+      throw new Error(`Unknown type "${resource.type}"`);
+    }
+  }
+
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['EntryFieldTypes', 'EntrySkeletonType'],
+    isTypeOnly: true,
+  });
+
+  return renderTypeGeneric('EntryFieldTypes.EntryResourceLink', 'EntrySkeletonType');
+};

--- a/src/renderer/field/render-prop-richtext.ts
+++ b/src/renderer/field/render-prop-richtext.ts
@@ -9,3 +9,13 @@ export const renderRichText = (field: ContentTypeField, context: RenderContext):
   });
   return 'EntryFields.RichText';
 };
+
+export const renderRichTextV10 = (field: ContentTypeField, context: RenderContext): string => {
+  context.imports.add({
+    moduleSpecifier: 'contentful',
+    namedImports: ['EntryFieldTypes'],
+    isTypeOnly: true,
+  });
+
+  return 'EntryFieldTypes.RichText';
+};

--- a/src/renderer/field/v10-renderers.ts
+++ b/src/renderer/field/v10-renderers.ts
@@ -1,0 +1,21 @@
+import { renderPropAnyV10 } from './render-prop-any';
+import { renderPropArrayV10 } from './render-prop-array';
+import { renderPropLinkV10 } from './render-prop-link';
+import { renderPropResourceLinkV10 } from './render-prop-resource-link';
+import { renderRichTextV10 } from './render-prop-richtext';
+import { FieldRenderers } from './render-types';
+
+export const v10Renderers: FieldRenderers = {
+  RichText: renderRichTextV10,
+  Link: renderPropLinkV10,
+  ResourceLink: renderPropResourceLinkV10,
+  Array: renderPropArrayV10,
+  Text: renderPropAnyV10,
+  Symbol: renderPropAnyV10,
+  Object: renderPropAnyV10,
+  Date: renderPropAnyV10,
+  Number: renderPropAnyV10,
+  Integer: renderPropAnyV10,
+  Boolean: renderPropAnyV10,
+  Location: renderPropAnyV10,
+};

--- a/src/renderer/generic/render-type-generic.ts
+++ b/src/renderer/generic/render-type-generic.ts
@@ -1,3 +1,3 @@
-export const renderTypeGeneric = (type: string, gen: string): string => {
-  return `${type}<${gen}>`;
+export const renderTypeGeneric = (type: string, ...gen: string[]): string => {
+  return `${type}<${gen.join(', ')}>`;
 };

--- a/src/renderer/type/create-v10-context.ts
+++ b/src/renderer/type/create-v10-context.ts
@@ -1,7 +1,8 @@
 import { ContentTypeFieldType } from 'contentful';
 import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
-import { moduleFieldsName, moduleName, moduleSkeletonName } from '../../module-name';
-import { defaultRenderers, FieldRenderer } from '../field';
+import { FieldRenderer } from '../field';
+import { createDefaultContext } from './create-default-context';
+import { v10Renderers } from '../field/v10-renderers';
 
 export type RenderContext = {
   getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;
@@ -11,13 +12,10 @@ export type RenderContext = {
   imports: Set<OptionalKind<ImportDeclarationStructure>>;
 };
 
-export const createDefaultContext = (): RenderContext => {
+export const createV10Context = (): RenderContext => {
   return {
-    moduleName,
-    moduleFieldsName,
-    moduleSkeletonName,
+    ...createDefaultContext(),
     getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) =>
-      defaultRenderers[fieldType] as FieldRenderer<FType>,
-    imports: new Set(),
+      v10Renderers[fieldType] as FieldRenderer<FType>,
   };
 };

--- a/src/renderer/type/create-v10-context.ts
+++ b/src/renderer/type/create-v10-context.ts
@@ -1,8 +1,7 @@
 import { ContentTypeFieldType } from 'contentful';
 import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
-import { FieldRenderer } from '../field';
+import { FieldRenderer, v10Renderers } from '../field';
 import { createDefaultContext } from './create-default-context';
-import { v10Renderers } from '../field/v10-renderers';
 
 export type RenderContext = {
   getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;

--- a/src/renderer/type/index.ts
+++ b/src/renderer/type/index.ts
@@ -1,8 +1,10 @@
 export { BaseContentTypeRenderer } from './base-content-type-renderer';
 export { ContentTypeRenderer } from './content-type-renderer';
 export { DefaultContentTypeRenderer } from './default-content-type-renderer';
+export { V10ContentTypeRenderer } from './v10-content-type-renderer';
 export { LocalizedContentTypeRenderer } from './localized-content-type-renderer';
 export { JsDocRenderer } from './js-doc-renderer';
 export { TypeGuardRenderer } from './type-guard-renderer';
 export { createDefaultContext } from './create-default-context';
+export { createV10Context } from './create-v10-context';
 export type { RenderContext } from './create-default-context';

--- a/src/renderer/type/v10-content-type-renderer.ts
+++ b/src/renderer/type/v10-content-type-renderer.ts
@@ -26,6 +26,10 @@ export class V10ContentTypeRenderer extends BaseContentTypeRenderer {
     for (const structure of context.imports) {
       file.addImportDeclaration(structure);
     }
+
+    file.organizeImports({
+      ensureNewLineAtEndOfFile: true,
+    });
   }
 
   protected renderFieldsInterface(

--- a/src/renderer/type/v10-content-type-renderer.ts
+++ b/src/renderer/type/v10-content-type-renderer.ts
@@ -1,0 +1,126 @@
+import { ContentTypeField } from 'contentful';
+import {
+  OptionalKind,
+  PropertySignatureStructure,
+  SourceFile,
+  TypeAliasDeclarationStructure,
+} from 'ts-morph';
+import { propertyImports } from '../../property-imports';
+import { renderTypeGeneric } from '../generic';
+import { CFContentType } from '../../types';
+import { BaseContentTypeRenderer } from './base-content-type-renderer';
+import { RenderContext } from './create-default-context';
+import { createV10Context } from './create-v10-context';
+
+export class V10ContentTypeRenderer extends BaseContentTypeRenderer {
+  public render(contentType: CFContentType, file: SourceFile): void {
+    const context = this.createContext();
+
+    this.addDefaultImports(context);
+    this.renderFieldsInterface(contentType, file, context);
+
+    file.addTypeAlias(this.renderEntrySkeleton(contentType, context));
+
+    file.addTypeAlias(this.renderEntry(contentType, context));
+
+    for (const structure of context.imports) {
+      file.addImportDeclaration(structure);
+    }
+  }
+
+  protected renderFieldsInterface(
+    contentType: CFContentType,
+    file: SourceFile,
+    context: RenderContext,
+  ): void {
+    const fieldsInterfaceName = context.moduleFieldsName(contentType.sys.id);
+    const interfaceDeclaration = file.addInterface({
+      name: fieldsInterfaceName,
+      isExported: true,
+    });
+
+    for (const field of contentType.fields) {
+      interfaceDeclaration.addProperty(this.renderField(field, context));
+      for (const pImport of propertyImports(field, context, file.getBaseNameWithoutExtension())) {
+        context.imports.add(pImport);
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
+  protected addDefaultImports(context: RenderContext): void {}
+
+  protected renderField(
+    field: ContentTypeField,
+    context: RenderContext,
+  ): OptionalKind<PropertySignatureStructure> {
+    return {
+      name: field.id,
+      hasQuestionToken: field.omitted || !field.required,
+      type: this.renderFieldType(field, context),
+    };
+  }
+
+  protected renderFieldType(field: ContentTypeField, context: RenderContext): string {
+    return context.getFieldRenderer(field.type)(field, context);
+  }
+
+  protected renderEntrySkeleton(
+    contentType: CFContentType,
+    context: RenderContext,
+  ): OptionalKind<TypeAliasDeclarationStructure> {
+    return {
+      name: context.moduleSkeletonName(contentType.sys.id),
+      isExported: true,
+      type: this.renderEntrySkeletonType(contentType, context),
+    };
+  }
+
+  protected renderEntrySkeletonType(contentType: CFContentType, context: RenderContext): string {
+    context.imports.add({
+      moduleSpecifier: 'contentful',
+      namedImports: ['EntrySkeletonType'],
+      isTypeOnly: true,
+    });
+
+    return renderTypeGeneric(
+      'EntrySkeletonType',
+      context.moduleFieldsName(contentType.sys.id),
+      `"${contentType.sys.id}"`,
+    );
+  }
+
+  protected renderEntry(
+    contentType: CFContentType,
+    context: RenderContext,
+  ): OptionalKind<TypeAliasDeclarationStructure> {
+    return {
+      name: renderTypeGeneric(
+        context.moduleName(contentType.sys.id),
+        'Modifiers extends ChainModifiers',
+        'Locales extends LocaleCode',
+      ),
+      isExported: true,
+      type: this.renderEntryType(contentType, context),
+    };
+  }
+
+  protected renderEntryType(contentType: CFContentType, context: RenderContext): string {
+    context.imports.add({
+      moduleSpecifier: 'contentful',
+      namedImports: ['ChainModifiers', 'Entry', 'LocaleCode'],
+      isTypeOnly: true,
+    });
+
+    return renderTypeGeneric(
+      'Entry',
+      context.moduleSkeletonName(contentType.sys.id),
+      'Modifiers',
+      'Locales',
+    );
+  }
+
+  public createContext(): RenderContext {
+    return createV10Context();
+  }
+}

--- a/src/renderer/type/v10-type-guard-renderer.ts
+++ b/src/renderer/type/v10-type-guard-renderer.ts
@@ -1,0 +1,56 @@
+import { Project, SourceFile } from 'ts-morph';
+import { moduleName } from '../../module-name';
+import { CFContentType } from '../../types';
+import { BaseContentTypeRenderer } from './base-content-type-renderer';
+import { renderTypeGeneric } from '../generic';
+
+export class V10TypeGuardRenderer extends BaseContentTypeRenderer {
+  private readonly files: SourceFile[];
+
+  private static readonly WithContentTypeLink = 'WithContentTypeLink';
+  constructor() {
+    super();
+    this.files = [];
+  }
+
+  public override setup(project: Project): void {
+    super.setup(project);
+  }
+
+  public render = (contentType: CFContentType, file: SourceFile): void => {
+    const entryInterfaceName = moduleName(contentType.sys.id);
+
+    file.addImportDeclaration({
+      moduleSpecifier: `contentful`,
+      namedImports: ['ChainModifiers', 'Entry', 'LocaleCode'],
+      isTypeOnly: true,
+    });
+
+    file.addFunction({
+      isExported: true,
+      name: renderTypeGeneric(
+        `is${entryInterfaceName}`,
+        'Modifiers extends ChainModifiers',
+        'Locales extends LocaleCode',
+      ),
+      returnType: `entry is ${renderTypeGeneric(entryInterfaceName, 'Modifiers', 'Locales')}`,
+      parameters: [
+        {
+          name: 'entry',
+          type: renderTypeGeneric('Entry', 'EntrySkeletonType', 'Modifiers', 'Locales'),
+        },
+      ],
+      statements: `return entry.sys.contentType.sys.id === '${contentType.sys.id}'`,
+    });
+
+    file.organizeImports({
+      ensureNewLineAtEndOfFile: true,
+    });
+
+    file.formatText();
+  };
+
+  public override additionalFiles(): SourceFile[] {
+    return this.files;
+  }
+}

--- a/test/renderer/field/render-prop-any.test.ts
+++ b/test/renderer/field/render-prop-any.test.ts
@@ -1,4 +1,10 @@
-import { createDefaultContext, RenderContext, renderPropAny } from '../../../src';
+import {
+  createDefaultContext,
+  createV10Context,
+  RenderContext,
+  renderPropAny,
+  renderPropAnyV10,
+} from '../../../src';
 
 describe('A renderPropAny function', () => {
   let context: RenderContext;
@@ -63,5 +69,73 @@ describe('A renderPropAny function', () => {
       `);
 
     expect(renderPropAny(field, context)).toEqual('EntryFields.Symbol');
+  });
+});
+
+describe('A renderPropAnyV10 function', () => {
+  let context: RenderContext;
+
+  beforeEach(() => {
+    context = createV10Context();
+  });
+
+  it('can evaluate a "Symbol" type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "internalName",
+          "name": "Internal name",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+        `);
+
+    expect(renderPropAnyV10(field, context)).toEqual('EntryFieldTypes.Symbol');
+  });
+
+  it('can evaluate a "Symbol" type with "in" validation', () => {
+    const field = JSON.parse(`
+        {
+          "id": "headerAlignment",
+          "name": "Header alignment",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "in": [
+                "Left-aligned",
+                "Center-aligned"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+        `);
+
+    expect(renderPropAnyV10(field, context)).toEqual(
+      'EntryFieldTypes.Symbol<"Center-aligned" | "Left-aligned">',
+    );
+  });
+
+  it('can evaluate a "Symbol" type with missing validations', () => {
+    const field = JSON.parse(`
+      {
+        "id": "internalName",
+        "name": "Internal name",
+        "type": "Symbol",
+        "localized": false,
+        "required": false,
+        "disabled": false,
+        "omitted": false
+      }
+      `);
+
+    expect(renderPropAnyV10(field, context)).toEqual('EntryFieldTypes.Symbol');
   });
 });

--- a/test/renderer/field/render-prop-array.test.ts
+++ b/test/renderer/field/render-prop-array.test.ts
@@ -1,4 +1,9 @@
-import { createDefaultContext, renderPropArray } from '../../../src';
+import {
+  createDefaultContext,
+  createV10Context,
+  renderPropArray,
+  renderPropArrayV10,
+} from '../../../src';
 
 describe('A renderPropArray function', () => {
   it('can evaluate a "Array" of "Link" with no validations', () => {
@@ -144,5 +149,158 @@ describe('A renderPropArray function', () => {
     `);
 
     expect(renderPropArray(field, createDefaultContext())).toEqual('Entry<Record<string, any>>[]');
+  });
+});
+
+describe('A renderPropArrayV10 function', () => {
+  it('can evaluate a "Array" of "Link" with no validations', () => {
+    const field = JSON.parse(`
+      {
+        "id": "components",
+        "name": "Components",
+        "type": "Array",
+        "localized": false,
+        "required": true,
+        "validations": [],
+        "disabled": false,
+        "omitted": false,
+        "items": {
+          "type": "Link",
+          "validations": [],
+          "linkType": "Entry"
+        }
+      }
+      `);
+
+    expect(renderPropArrayV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.Array<EntryFieldTypes.EntryLink<EntrySkeletonType>>',
+    );
+  });
+
+  it('can evaluate an "Array" of "Symbol"', () => {
+    const field = JSON.parse(`
+        {
+          "id": "tags",
+          "name": "Tags (optional)",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+            ]
+          }
+        }
+        `);
+
+    expect(renderPropArrayV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.Array<EntryFieldTypes.Symbol>',
+    );
+  });
+
+  it('can evaluate an "Array" of "Symbol" with "in" validation', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category (optional)",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": [
+                  "Feature",
+                  "Benefit",
+                  "Tech spec",
+                  "Other"
+                ]
+              }
+            ]
+          }
+        }
+        `);
+
+    expect(renderPropArrayV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.Array<EntryFieldTypes.Symbol<"Benefit" | "Feature" | "Other" | "Tech spec">>',
+    );
+  });
+
+  it('can evaluate an "Array" of "Link" with "linkContentType" validation', () => {
+    const field = JSON.parse(`
+        {
+          "id": "extraSections",
+          "name": "Extra sections (optional)",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+              {
+                "linkContentType": [
+                  "componentCta",
+                  "componentFaq",
+                  "wrapperImage",
+                  "wrapperVideo"
+                ]
+              }
+            ],
+            "linkType": "Entry"
+          }
+        }
+        `);
+
+    expect(renderPropArrayV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.Array<EntryFieldTypes.EntryLink<TypeComponentCtaSkeleton | TypeComponentFaqSkeleton | TypeWrapperImageSkeleton | TypeWrapperVideoSkeleton>>',
+    );
+  });
+
+  it('can evaluate a "Array" of "ResourceLink"', () => {
+    const field = JSON.parse(`
+      {
+        "id": "components",
+        "name": "Components",
+        "type": "Array",
+        "localized": false,
+        "required": true,
+        "validations": [],
+        "disabled": false,
+        "omitted": false,
+        "items": {
+          "type": "ResourceLink",
+          "validations": []
+        },
+        "allowedResources": [
+          {
+            "type": "Contentful:Entry",
+            "source": "crn:contentful:::content:spaces/spaceId",
+            "contentTypes": [
+              "componentCta",
+              "componentFaq",
+              "wrapperImage",
+              "wrapperVideo"
+            ]
+          }
+        ]
+      }
+    `);
+
+    expect(renderPropArrayV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.Array<EntryFieldTypes.EntryResourceLink<EntrySkeletonType>>',
+    );
   });
 });

--- a/test/renderer/field/render-prop-link.test.ts
+++ b/test/renderer/field/render-prop-link.test.ts
@@ -1,4 +1,9 @@
-import { createDefaultContext, renderPropLink } from '../../../src';
+import {
+  createDefaultContext,
+  createV10Context,
+  renderPropLink,
+  renderPropLinkV10,
+} from '../../../src';
 
 describe('A renderPropLink function', () => {
   it('can evaluate a "Link" type', () => {
@@ -41,5 +46,80 @@ describe('A renderPropLink function', () => {
       `);
 
     expect(renderPropLink(field, createDefaultContext())).toEqual('Entry<Record<string, any>>');
+  });
+});
+
+describe('A renderPropLinkV10 function', () => {
+  it('can evaluate a "Link" type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "linkContentType": [
+                "topicCategory"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        }
+        `);
+
+    expect(renderPropLinkV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.EntryLink<TypeTopicCategorySkeleton>',
+    );
+  });
+
+  it('can evaluate a "Link" type with multiple linked content types', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "linkContentType": [
+                "topicCategoryA",
+                "topicCategoryB"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        }
+        `);
+
+    expect(renderPropLinkV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.EntryLink<TypeTopicCategoryASkeleton | TypeTopicCategoryBSkeleton>',
+    );
+  });
+
+  it('can evaluate a "Link" type with no validations', () => {
+    const field = JSON.parse(`
+      {
+        "id": "components",
+        "name": "Components",
+        "type": "Link",
+        "localized": false,
+        "required": true,
+        "validations": [],
+        "disabled": false,
+        "omitted": false,
+        "linkType": "Entry"
+      }
+      `);
+
+    expect(renderPropLinkV10(field, createV10Context())).toEqual(
+      'EntryFieldTypes.EntryLink<EntrySkeletonType>',
+    );
   });
 });

--- a/test/renderer/field/render-prop-resource-link.test.ts
+++ b/test/renderer/field/render-prop-resource-link.test.ts
@@ -1,4 +1,8 @@
-import { createDefaultContext, renderPropResourceLink } from '../../../src';
+import {
+  createDefaultContext,
+  renderPropResourceLink,
+  renderPropResourceLinkV10,
+} from '../../../src';
 
 describe('A renderPropResourceLink function', () => {
   it('can evaluate a "ResourceLink" type', () => {
@@ -53,6 +57,63 @@ describe('A renderPropResourceLink function', () => {
       `);
 
     expect(() => renderPropResourceLink(field, createDefaultContext())).toThrow(
+      'Unknown type "Contentful:UnknownEntity"',
+    );
+  });
+});
+describe('A renderPropResourceLinkV10 function', () => {
+  it('can evaluate a "ResourceLink" type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "ResourceLink",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "allowedResources": [
+            {
+              "type": "Contentful:Entry",
+              "source": "crn:contentful:::content:spaces/spaceId",
+                "contentTypes": [
+                "topicCategory"
+              ]
+            }
+          ]
+         }
+        `);
+
+    expect(renderPropResourceLinkV10(field, createDefaultContext())).toEqual(
+      'EntryFieldTypes.EntryResourceLink<EntrySkeletonType>',
+    );
+  });
+
+  it('rejects a "ResourceLink" with an unknown resource type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "ResourceLink",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "allowedResources": [
+            {
+              "type": "Contentful:UnknownEntity",
+              "source": "crn:contentful:::content:spaces/spaceId",
+                "contentTypes": [
+                "topicCategory"
+              ]
+            }
+          ]
+         }
+      `);
+
+    expect(() => renderPropResourceLinkV10(field, createDefaultContext())).toThrow(
       'Unknown type "Contentful:UnknownEntity"',
     );
   });

--- a/test/renderer/field/render-prop-richtext.test.ts
+++ b/test/renderer/field/render-prop-richtext.test.ts
@@ -1,4 +1,4 @@
-import { createDefaultContext, renderRichText } from '../../../src';
+import { createDefaultContext, renderRichText, renderRichTextV10 } from '../../../src';
 
 describe('A renderPropRichText function', () => {
   it('can evaluate a "RichText" type', () => {
@@ -24,6 +24,36 @@ describe('A renderPropRichText function', () => {
       {
         moduleSpecifier: 'contentful',
         namedImports: ['EntryFields'],
+        isTypeOnly: true,
+      },
+    ]);
+  });
+});
+
+describe('A renderPropRichTextV10 function', () => {
+  it('can evaluate a "RichText" type', () => {
+    const field = JSON.parse(`
+        {
+          "id": "info",
+          "name": "Info",
+          "type": "RichText",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        }
+        `);
+
+    const context = createDefaultContext();
+    const result = renderRichTextV10(field, context);
+
+    expect(result).toEqual('EntryFieldTypes.RichText');
+
+    expect([...context.imports.values()]).toEqual([
+      {
+        moduleSpecifier: 'contentful',
+        namedImports: ['EntryFieldTypes'],
         isTypeOnly: true,
       },
     ]);

--- a/test/renderer/type/content-type-renderer.test.ts
+++ b/test/renderer/type/content-type-renderer.test.ts
@@ -8,6 +8,7 @@ import {
   FieldRenderer,
   moduleFieldsName,
   moduleName,
+  moduleSkeletonName,
   RenderContext,
   renderTypeGeneric,
 } from '../../../src';
@@ -38,6 +39,7 @@ describe('A derived content type renderer class', () => {
         return {
           moduleName,
           moduleFieldsName,
+          moduleSkeletonName,
           getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => {
             if (fieldType === 'Symbol') {
               return symbolTypeRenderer as FieldRenderer<FType>;

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -1,5 +1,10 @@
 import { Project, ScriptTarget, SourceFile } from 'ts-morph';
-import { CFContentType, DefaultContentTypeRenderer, JsDocRenderer } from '../../../src';
+import {
+  CFContentType,
+  DefaultContentTypeRenderer,
+  JsDocRenderer,
+  V10ContentTypeRenderer,
+} from '../../../src';
 import {
   defaultJsDocRenderOptions,
   JSDocRenderOptions,
@@ -78,6 +83,51 @@ describe('A JSDoc content type renderer class', () => {
          * @type {TypeAnimal}
          */
         export type TypeAnimal = Entry<TypeAnimalFields>;
+        `),
+      );
+    });
+
+    it('renders JSDocs with v10 flag', () => {
+      const v10Renderer = new V10ContentTypeRenderer();
+      v10Renderer.setup(project);
+      v10Renderer.render(mockContentType, testFile);
+
+      const docsRenderer = new JsDocRenderer();
+      docsRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import type { EntryFieldTypes } from "contentful";
+        import type { EntrySkeletonType } from "contentful";
+        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimal'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            /**
+             * Field type definition for field 'bread' (Bread)
+             * @name Bread
+             * @localized false
+             */
+            bread: EntryFieldTypes.Symbol;
+        }
+        
+        /**
+         * Entry skeleton type definition for content type 'animal' (Animal)
+         * @name TypeAnimalSkeleton
+         * @type {TypeAnimalSkeleton}
+         */
+        export type TypeAnimalSkeleton = EntrySkeletonType<TypeAnimalFields, "animal">;
+        /**
+         * Entry type definition for content type 'animal' (Animal)
+         * @name TypeAnimal
+         * @type {TypeAnimal}
+         */
+        export type TypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeAnimalSkeleton, Modifiers, Locales>;
         `),
       );
     });

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -97,9 +97,7 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import type { EntryFieldTypes } from "contentful";
-        import type { EntrySkeletonType } from "contentful";
-        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+        import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'

--- a/test/renderer/type/v10-content-type-renderer.test.ts
+++ b/test/renderer/type/v10-content-type-renderer.test.ts
@@ -77,8 +77,7 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import type { EntrySkeletonType } from "contentful";
-        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+        import type { ChainModifiers, Entry, EntrySkeletonType, LocaleCode } from "contentful";
         
         export interface TypeTestFields {
             field_id: Test.Symbol;
@@ -141,9 +140,7 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import type { EntryFieldTypes } from "contentful";
-        import type { EntrySkeletonType } from "contentful";
-        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+        import type { Entry, EntryFieldTypes, EntrySkeletonType } from "contentful";
         
         export interface TypeTestFields {
             /** Field of type "Symbol" */
@@ -200,9 +197,8 @@ describe('A derived content type renderer class', () => {
 
     expect('\n' + testFile.getFullText()).toEqual(
       stripIndent(`
-        import type { EntryFieldTypes } from "contentful";
-        import type { EntrySkeletonType } from "contentful";
         import type { CustomEntry } from "@custom";
+        import type { EntryFieldTypes, EntrySkeletonType } from "contentful";
         
         export interface TypeTestFields {
             field_id: EntryFieldTypes.Symbol;

--- a/test/renderer/type/v10-content-type-renderer.test.ts
+++ b/test/renderer/type/v10-content-type-renderer.test.ts
@@ -1,0 +1,216 @@
+import { ContentTypeField, ContentTypeFieldType } from 'contentful';
+
+import { Project, ScriptTarget, SourceFile } from 'ts-morph';
+import {
+  CFContentType,
+  V10ContentTypeRenderer,
+  defaultRenderers,
+  FieldRenderer,
+  moduleFieldsName,
+  moduleName,
+  moduleSkeletonName,
+  RenderContext,
+  renderTypeGeneric,
+} from '../../../src';
+import stripIndent = require('strip-indent');
+
+describe('A derived content type renderer class', () => {
+  let project: Project;
+  let testFile: SourceFile;
+
+  beforeEach(() => {
+    project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        target: ScriptTarget.ES5,
+        declaration: true,
+      },
+    });
+    testFile = project.createSourceFile('test.ts');
+  });
+
+  it('can return a custom field type renderer', () => {
+    const symbolTypeRenderer = () => {
+      return 'Test.Symbol';
+    };
+
+    class DerivedContentTypeRenderer extends V10ContentTypeRenderer {
+      public createContext(): RenderContext {
+        return {
+          moduleName,
+          moduleFieldsName,
+          moduleSkeletonName,
+          getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => {
+            if (fieldType === 'Symbol') {
+              return symbolTypeRenderer as FieldRenderer<FType>;
+            }
+            return defaultRenderers[fieldType] as FieldRenderer<FType>;
+          },
+          imports: new Set(),
+        };
+      }
+    }
+
+    const renderer = new DerivedContentTypeRenderer();
+
+    const contentType: CFContentType = {
+      name: 'unused-name',
+      sys: {
+        id: 'test',
+        type: 'Symbol',
+      },
+      fields: [
+        {
+          id: 'field_id',
+          name: 'field_name',
+          disabled: false,
+          localized: false,
+          required: true,
+          type: 'Symbol',
+          omitted: false,
+          validations: [],
+        },
+      ],
+    };
+
+    renderer.render(contentType, testFile);
+
+    expect('\n' + testFile.getFullText()).toEqual(
+      stripIndent(`
+        import type { EntrySkeletonType } from "contentful";
+        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+        
+        export interface TypeTestFields {
+            field_id: Test.Symbol;
+        }
+        
+        export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
+        export type TypeTest<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeTestSkeleton, Modifiers, Locales>;
+        `),
+    );
+  });
+
+  it('can return a custom field renderer with docs support', () => {
+    class DerivedContentTypeRenderer extends V10ContentTypeRenderer {
+      protected renderField(field: ContentTypeField, context: RenderContext) {
+        return {
+          docs: [{ description: `Field of type "${field.type}"` }],
+          name: field.id,
+          hasQuestionToken: field.omitted || !field.required,
+          type: super.renderFieldType(field, context),
+        };
+      }
+
+      protected renderEntry(contentType: CFContentType, context: RenderContext) {
+        return {
+          docs: [
+            {
+              description: `content type "${contentType.name}" with id: ${contentType.sys.id}`,
+            },
+          ],
+          name: context.moduleName(contentType.sys.id),
+          isExported: true,
+          type: super.renderEntryType(contentType, context),
+        };
+      }
+    }
+
+    const renderer = new DerivedContentTypeRenderer();
+
+    const contentType: CFContentType = {
+      name: 'display name',
+      sys: {
+        id: 'test',
+        type: 'Symbol',
+      },
+      fields: [
+        {
+          id: 'field_id',
+          name: 'field_name',
+          disabled: false,
+          localized: false,
+          required: true,
+          type: 'Symbol',
+          omitted: false,
+          validations: [],
+        },
+      ],
+    };
+
+    renderer.render(contentType, testFile);
+
+    expect('\n' + testFile.getFullText()).toEqual(
+      stripIndent(`
+        import type { EntryFieldTypes } from "contentful";
+        import type { EntrySkeletonType } from "contentful";
+        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+        
+        export interface TypeTestFields {
+            /** Field of type "Symbol" */
+            field_id: EntryFieldTypes.Symbol;
+        }
+        
+        export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
+        /** content type "display name" with id: test */
+        export type TypeTest = Entry<TypeTestSkeleton, Modifiers, Locales>;
+        `),
+    );
+  });
+
+  it('can render custom entries', () => {
+    class DerivedContentTypeRenderer extends V10ContentTypeRenderer {
+      protected renderEntryType(contentType: CFContentType, context: RenderContext): string {
+        context.imports.add({
+          moduleSpecifier: '@custom',
+          namedImports: ['CustomEntry'],
+          isTypeOnly: true,
+        });
+        return renderTypeGeneric(
+          'CustomEntry',
+          context.moduleSkeletonName(contentType.sys.id),
+          'Modifiers',
+          'Locales',
+        );
+      }
+    }
+
+    const renderer = new DerivedContentTypeRenderer();
+
+    const contentType: CFContentType = {
+      name: 'display name',
+      sys: {
+        id: 'test',
+        type: 'Symbol',
+      },
+      fields: [
+        {
+          id: 'field_id',
+          name: 'field_name',
+          disabled: false,
+          localized: false,
+          required: true,
+          type: 'Symbol',
+          omitted: false,
+          validations: [],
+        },
+      ],
+    };
+
+    renderer.render(contentType, testFile);
+
+    expect('\n' + testFile.getFullText()).toEqual(
+      stripIndent(`
+        import type { EntryFieldTypes } from "contentful";
+        import type { EntrySkeletonType } from "contentful";
+        import type { CustomEntry } from "@custom";
+        
+        export interface TypeTestFields {
+            field_id: EntryFieldTypes.Symbol;
+        }
+        
+        export type TypeTestSkeleton = EntrySkeletonType<TypeTestFields, "test">;
+        export type TypeTest<Modifiers extends ChainModifiers, Locales extends LocaleCode> = CustomEntry<TypeTestSkeleton, Modifiers, Locales>;
+        `),
+    );
+  });
+});


### PR DESCRIPTION
Add `--v10` option to generate types compatible with contentful.js v10.

## Details

* Add new renderer for v10 types
* Add new renderer for v10 type guards
* Update JsDoc renderer to support new skeleton type
* Add `--v10` option to switch to v10 renderer
* Support combining other options with `--v10` (except for `--localized` which is redundant and throws error)

## Example output
```typescript
import type { ChainModifiers, Entry, EntryFieldTypes, EntrySkeletonType, LocaleCode } from "contentful";

export interface TypeAllFieldsFields {
    richText?: EntryFieldTypes.RichText;
    symbol?: EntryFieldTypes.Symbol;
    symbolWithValues?: EntryFieldTypes.Symbol<"option a" | "option b">;
    symbolList?: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
    symbolListWithValues?: EntryFieldTypes.Array<EntryFieldTypes.Symbol<"option a" | "option b">>;
    text?: EntryFieldTypes.Text;
    textWithValues?: EntryFieldTypes.Text<"option a" | "option b">;
    integer?: EntryFieldTypes.Integer;
    integerWithValues?: EntryFieldTypes.Integer<1 | 2 | 3>;
    decimal?: EntryFieldTypes.Number;
    decimalWithValues?: EntryFieldTypes.Number<1 | 2 | 3>;
    datetime?: EntryFieldTypes.Date;
    location?: EntryFieldTypes.Location;
    media?: EntryFieldTypes.AssetLink;
    mediaList?: EntryFieldTypes.Array<EntryFieldTypes.AssetLink>;
    boolean?: EntryFieldTypes.Boolean;
    json?: EntryFieldTypes.Object;
    reference?: EntryFieldTypes.EntryLink<EntrySkeletonType>;
    referenceWith1Ct?: EntryFieldTypes.EntryLink<TypeLinkedContentType1Skeleton>;
    referenceWith2CTs?: EntryFieldTypes.EntryLink<TypeLinkedContentType1Skeleton | TypeLinkedContentType2Skeleton>;
    referenceList?: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<EntrySkeletonType>>;
    referenceListWith1Ct?: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<TypeLinkedContentType1Skeleton>>;
    referenceListWith2CTs?: EntryFieldTypes.Array<EntryFieldTypes.EntryLink<TypeLinkedContentType1Skeleton | TypeLinkedContentType2Skeleton>>;
    resourceLink?: EntryFieldTypes.EntryResourceLink<EntrySkeletonType>;
}

export type TypeAllFieldsSkeleton = EntrySkeletonType<TypeAllFieldsFields, "allFields">;
export type TypeAllFields<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeAllFieldsSkeleton, Modifiers, Locales>;

export function isTypeAllFields<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAllFields<Modifiers, Locales> {
    return entry.sys.contentType.sys.id === 'allFields'
}

export interface TypeLinkedContentType1Fields {
    title?: EntryFieldTypes.Symbol;
}

export type TypeLinkedContentType1Skeleton = EntrySkeletonType<TypeLinkedContentType1Fields, "linkedContentType1">;
export type TypeLinkedContentType1<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeLinkedContentType1Skeleton, Modifiers, Locales>;

export function isTypeLinkedContentType1<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeLinkedContentType1<Modifiers, Locales> {
    return entry.sys.contentType.sys.id === 'linkedContentType1'
}

export interface TypeLinkedContentType2Fields {
    title?: EntryFieldTypes.Symbol;
}

export type TypeLinkedContentType2Skeleton = EntrySkeletonType<TypeLinkedContentType2Fields, "linkedContentType2">;
export type TypeLinkedContentType2<Modifiers extends ChainModifiers, Locales extends LocaleCode> = Entry<TypeLinkedContentType2Skeleton, Modifiers, Locales>;

export function isTypeLinkedContentType2<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeLinkedContentType2<Modifiers, Locales> {
    return entry.sys.contentType.sys.id === 'linkedContentType2'
}
```