### PR TITLE
fix: top level export for v10 typeguard

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,11 +7,11 @@ import {
   ContentTypeRenderer,
   DefaultContentTypeRenderer,
   V10ContentTypeRenderer,
+  V10TypeGuardRenderer,
   JsDocRenderer,
   LocalizedContentTypeRenderer,
   TypeGuardRenderer,
 } from './renderer';
-import { V10TypeGuardRenderer } from './renderer/type/v10-type-guard-renderer';
 
 // eslint-disable-next-line unicorn/prefer-module
 const contentfulExport = require('contentful-export');

--- a/src/renderer/type/index.ts
+++ b/src/renderer/type/index.ts
@@ -2,6 +2,7 @@ export { BaseContentTypeRenderer } from './base-content-type-renderer';
 export { ContentTypeRenderer } from './content-type-renderer';
 export { DefaultContentTypeRenderer } from './default-content-type-renderer';
 export { V10ContentTypeRenderer } from './v10-content-type-renderer';
+export { V10TypeGuardRenderer } from './v10-type-guard-renderer';
 export { LocalizedContentTypeRenderer } from './localized-content-type-renderer';
 export { JsDocRenderer } from './js-doc-renderer';
 export { TypeGuardRenderer } from './type-guard-renderer';


### PR DESCRIPTION
Add missing top-level export for `V10TypeGuardRenderer`