### PR TITLE
fix: import skeleton for links in v10 types

### DIFF
--- a/src/property-imports.ts
+++ b/src/property-imports.ts
@@ -13,7 +13,7 @@ export const propertyImports = (
   const moduleImport = (module: string): OptionalKind<ImportDeclarationStructure> => {
     return {
       moduleSpecifier: `./${context.moduleName(module)}`,
-      namedImports: [context.moduleFieldsName(module)],
+      namedImports: [context.moduleReferenceName(module)],
       isTypeOnly: true,
     };
   };

--- a/src/renderer/type/create-default-context.ts
+++ b/src/renderer/type/create-default-context.ts
@@ -7,6 +7,7 @@ export type RenderContext = {
   getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;
   moduleName: (id: string) => string;
   moduleFieldsName: (id: string) => string;
+  moduleReferenceName: (id: string) => string;
   moduleSkeletonName: (id: string) => string;
   imports: Set<OptionalKind<ImportDeclarationStructure>>;
 };
@@ -16,6 +17,7 @@ export const createDefaultContext = (): RenderContext => {
     moduleName,
     moduleFieldsName,
     moduleSkeletonName,
+    moduleReferenceName: moduleFieldsName,
     getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) =>
       defaultRenderers[fieldType] as FieldRenderer<FType>,
     imports: new Set(),

--- a/src/renderer/type/create-v10-context.ts
+++ b/src/renderer/type/create-v10-context.ts
@@ -2,11 +2,13 @@ import { ContentTypeFieldType } from 'contentful';
 import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
 import { FieldRenderer, v10Renderers } from '../field';
 import { createDefaultContext } from './create-default-context';
+import { moduleSkeletonName } from '../../module-name';
 
 export type RenderContext = {
   getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;
   moduleName: (id: string) => string;
   moduleFieldsName: (id: string) => string;
+  moduleReferenceName: (id: string) => string;
   moduleSkeletonName: (id: string) => string;
   imports: Set<OptionalKind<ImportDeclarationStructure>>;
 };
@@ -14,6 +16,7 @@ export type RenderContext = {
 export const createV10Context = (): RenderContext => {
   return {
     ...createDefaultContext(),
+    moduleReferenceName: moduleSkeletonName,
     getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) =>
       v10Renderers[fieldType] as FieldRenderer<FType>,
   };

--- a/src/renderer/type/default-content-type-renderer.ts
+++ b/src/renderer/type/default-content-type-renderer.ts
@@ -23,6 +23,10 @@ export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
     for (const structure of context.imports) {
       file.addImportDeclaration(structure);
     }
+
+    file.organizeImports({
+      ensureNewLineAtEndOfFile: true,
+    });
   }
 
   protected renderFieldsInterface(

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -59,8 +59,7 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import type { EntryFields } from "contentful";
-        import type { Entry } from "contentful";
+        import type { Entry, EntryFields } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -148,8 +147,7 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import type { EntryFields } from "contentful";
-        import type { Entry } from "contentful";
+        import type { Entry, EntryFields } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -191,8 +189,7 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import type { EntryFields } from "contentful";
-        import type { Entry } from "contentful";
+        import type { Entry, EntryFields } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -234,8 +231,7 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import type { EntryFields } from "contentful";
-        import type { Entry } from "contentful";
+        import type { Entry, EntryFields } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'
@@ -285,8 +281,7 @@ describe('A JSDoc content type renderer class', () => {
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`
-        import type { EntryFields } from "contentful";
-        import type { Entry } from "contentful";
+        import type { Entry, EntryFields } from "contentful";
         
         /**
          * Fields type definition for content type 'TypeAnimal'


### PR DESCRIPTION
Fixes https://github.com/contentful-userland/cf-content-types-generator/issues/249. The v10 renderer provided relative imports for the field type despite only using the skeleton type in links.

## Changes
* Change provided imports from field type to skeleton type in v10 context
* Simplify imports for the v9 renderer (same as v10 already does)
* Add tests for both v9 and v10 imports.