### PR TITLE
feat: Add field help texts to generated JSDoc

### DIFF
--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -38,7 +38,7 @@ export default class CFDefinitionsBuilder {
 
   public appendType = (
     model: CFContentType,
-    editorInterfaces?: CFEditorInterface[],
+    editorInterface?: CFEditorInterface,
   ): CFDefinitionsBuilder => {
     if (model.sys.type !== 'ContentType') {
       throw new Error('given data is not describing a ContentType');
@@ -46,7 +46,7 @@ export default class CFDefinitionsBuilder {
 
     const file = this.addFile(moduleName(model.sys.id));
     for (const renderer of this.contentTypeRenderers) {
-      renderer.render(model, file, editorInterfaces);
+      renderer.render(model, file, editorInterface);
     }
 
     file.organizeImports({
@@ -58,10 +58,10 @@ export default class CFDefinitionsBuilder {
 
   public appendTypes = (
     models: CFContentType[],
-    editorInterfaces?: CFEditorInterface[],
+    editorInterface?: CFEditorInterface,
   ): CFDefinitionsBuilder => {
     for (const model of models) {
-      this.appendType(model, editorInterfaces);
+      this.appendType(model, editorInterface);
     }
 
     return this;

--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -9,7 +9,7 @@ import {
 } from 'ts-morph';
 import { moduleName } from './module-name';
 import { ContentTypeRenderer, DefaultContentTypeRenderer } from './renderer';
-import { CFContentType, WriteCallback } from './types';
+import { CFContentType, CFEditorInterface, WriteCallback } from './types';
 import { flatten } from 'lodash';
 
 export default class CFDefinitionsBuilder {
@@ -36,14 +36,17 @@ export default class CFDefinitionsBuilder {
     }
   }
 
-  public appendType = (model: CFContentType): CFDefinitionsBuilder => {
+  public appendType = (
+    model: CFContentType,
+    editorInterfaces?: CFEditorInterface[],
+  ): CFDefinitionsBuilder => {
     if (model.sys.type !== 'ContentType') {
       throw new Error('given data is not describing a ContentType');
     }
 
     const file = this.addFile(moduleName(model.sys.id));
     for (const renderer of this.contentTypeRenderers) {
-      renderer.render(model, file);
+      renderer.render(model, file, editorInterfaces);
     }
 
     file.organizeImports({
@@ -53,9 +56,12 @@ export default class CFDefinitionsBuilder {
     return this;
   };
 
-  public appendTypes = (models: CFContentType[]): CFDefinitionsBuilder => {
+  public appendTypes = (
+    models: CFContentType[],
+    editorInterfaces?: CFEditorInterface[],
+  ): CFDefinitionsBuilder => {
     for (const model of models) {
-      this.appendType(model);
+      this.appendType(model, editorInterfaces);
     }
 
     return this;

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -15,6 +15,7 @@ import {
   V10ContentTypeRenderer,
   V10TypeGuardRenderer,
 } from '../renderer';
+import { CFEditorInterface } from '../types';
 
 class ContentfulMdg extends Command {
   static description = 'Contentful Content Types (TS Definitions) Generator';
@@ -91,9 +92,14 @@ class ContentfulMdg extends Command {
       renderers.push(flags.v10 ? new V10TypeGuardRenderer() : new TypeGuardRenderer());
     }
 
+    const editorInterfaces = content.editorInterfaces as CFEditorInterface[] | undefined;
+
     const builder = new CFDefinitionsBuilder(renderers);
     for (const model of content.contentTypes) {
-      builder.appendType(model, content.editorInterfaces);
+      const editorInterface = editorInterfaces?.find(
+        (e) => e.sys.contentType.sys.id === model.sys.id,
+      );
+      builder.appendType(model, editorInterface);
     }
 
     if (flags.out) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -63,7 +63,6 @@ class ContentfulMdg extends Command {
         spaceId: flags.spaceId,
         managementToken: flags.token,
         environmentId: flags.environment,
-        skipEditorInterfaces: true,
         skipContent: true,
         skipRoles: true,
         skipWebhooks: true,
@@ -94,7 +93,7 @@ class ContentfulMdg extends Command {
 
     const builder = new CFDefinitionsBuilder(renderers);
     for (const model of content.contentTypes) {
-      builder.appendType(model);
+      builder.appendType(model, content.editorInterfaces);
     }
 
     if (flags.out) {

--- a/src/renderer/type/content-type-renderer.ts
+++ b/src/renderer/type/content-type-renderer.ts
@@ -5,11 +5,7 @@ import { RenderContext } from './create-default-context';
 export interface ContentTypeRenderer {
   setup(project: Project): void;
 
-  render(
-    contentType: CFContentType,
-    file: SourceFile,
-    editorInterfaces?: CFEditorInterface[],
-  ): void;
+  render(contentType: CFContentType, file: SourceFile, editorInterface?: CFEditorInterface): void;
 
   createContext(): RenderContext;
 

--- a/src/renderer/type/content-type-renderer.ts
+++ b/src/renderer/type/content-type-renderer.ts
@@ -1,11 +1,15 @@
 import { Project, SourceFile } from 'ts-morph';
-import { CFContentType } from '../../types';
+import { CFContentType, CFEditorInterface } from '../../types';
 import { RenderContext } from './create-default-context';
 
 export interface ContentTypeRenderer {
   setup(project: Project): void;
 
-  render(contentType: CFContentType, file: SourceFile): void;
+  render(
+    contentType: CFContentType,
+    file: SourceFile,
+    editorInterfaces?: CFEditorInterface[],
+  ): void;
 
   createContext(): RenderContext;
 

--- a/src/renderer/type/js-doc-renderer.ts
+++ b/src/renderer/type/js-doc-renderer.ts
@@ -113,7 +113,7 @@ export const defaultJsDocRenderOptions: Required<JSDocRenderOptions> = {
 
     if (control?.settings?.helpText) {
       tags.push({
-        tagName: 'helpText',
+        tagName: 'summary',
         text: control?.settings?.helpText,
       });
     }

--- a/src/renderer/type/js-doc-renderer.ts
+++ b/src/renderer/type/js-doc-renderer.ts
@@ -183,7 +183,7 @@ export class JsDocRenderer extends BaseContentTypeRenderer {
   public render = (
     contentType: CFContentType,
     file: SourceFile,
-    editorInterfaces?: CFEditorInterface[],
+    editorInterface?: CFEditorInterface,
   ): void => {
     const context = this.createContext();
 
@@ -212,10 +212,6 @@ export class JsDocRenderer extends BaseContentTypeRenderer {
       );
 
       const fields = fieldsInterface.getProperties();
-
-      const editorInterface = editorInterfaces?.find(
-        (e) => e.sys.contentType.sys.id === contentType.sys.id,
-      );
 
       for (const field of fields) {
         const fieldName = field.getName();

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,3 +10,21 @@ export type CFContentType = {
   };
   fields: ContentTypeField[];
 };
+
+export type CFEditorInterface = {
+  sys: {
+    contentType: {
+      sys: {
+        id: string;
+      };
+    };
+  };
+  controls: CFEditorInterfaceControl[];
+};
+
+export type CFEditorInterfaceControl = {
+  fieldId: string;
+  settings?: {
+    helpText: string;
+  };
+};

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -1,6 +1,7 @@
 import { Project, ScriptTarget, SourceFile } from 'ts-morph';
 import {
   CFContentType,
+  CFEditorInterface,
   DefaultContentTypeRenderer,
   JsDocRenderer,
   V10ContentTypeRenderer,
@@ -266,14 +267,12 @@ describe('A JSDoc content type renderer class', () => {
 
       const docsRenderer = new JsDocRenderer();
 
-      docsRenderer.render(mockContentType, testFile, [
-        {
-          sys: { contentType: { sys: { id: 'animal' } } },
-          controls: [
-            { fieldId: 'bread', settings: { helpText: 'Help text for the bread field.' } },
-          ],
-        },
-      ]);
+      const editorInterface: CFEditorInterface = {
+        sys: { contentType: { sys: { id: 'animal' } } },
+        controls: [{ fieldId: 'bread', settings: { helpText: 'Help text for the bread field.' } }],
+      };
+
+      docsRenderer.render(mockContentType, testFile, editorInterface);
 
       expect('\n' + testFile.getFullText()).toEqual(
         stripIndent(`

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -259,7 +259,7 @@ describe('A JSDoc content type renderer class', () => {
       );
     });
 
-    it('renders field @helpText tag', () => {
+    it('renders field @summary tag', () => {
       const defaultRenderer = new DefaultContentTypeRenderer();
       defaultRenderer.setup(project);
       defaultRenderer.render(mockContentType, testFile);
@@ -290,7 +290,7 @@ describe('A JSDoc content type renderer class', () => {
              * Field type definition for field 'bread' (Bread)
              * @name Bread
              * @localized false
-             * @helpText Help text for the bread field.
+             * @summary Help text for the bread field.
              */
             bread: EntryFields.Symbol;
         }

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -258,6 +258,52 @@ describe('A JSDoc content type renderer class', () => {
         `),
       );
     });
+
+    it('renders field @helpText tag', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+      defaultRenderer.render(mockContentType, testFile);
+
+      const docsRenderer = new JsDocRenderer();
+
+      docsRenderer.render(mockContentType, testFile, [
+        {
+          sys: { contentType: { sys: { id: 'animal' } } },
+          controls: [
+            { fieldId: 'bread', settings: { helpText: 'Help text for the bread field.' } },
+          ],
+        },
+      ]);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import type { Entry, EntryFields } from "contentful";
+        
+        /**
+         * Fields type definition for content type 'TypeAnimal'
+         * @name TypeAnimalFields
+         * @type {TypeAnimalFields}
+         * @memberof TypeAnimal
+         */
+        export interface TypeAnimalFields {
+            /**
+             * Field type definition for field 'bread' (Bread)
+             * @name Bread
+             * @localized false
+             * @helpText Help text for the bread field.
+             */
+            bread: EntryFields.Symbol;
+        }
+        
+        /**
+         * Entry type definition for content type 'animal' (Animal)
+         * @name TypeAnimal
+         * @type {TypeAnimal}
+         */
+        export type TypeAnimal = Entry<TypeAnimalFields>;
+        `),
+      );
+    });
   });
 
   describe('with custom Entry Docs renderer', () => {


### PR DESCRIPTION
Add field help texts to generated JSDoc comments. The help text is added as a new [`@summary`](https://jsdoc.app/tags-summary) tag so that the existing functionality is not changed in a breaking way. For example:

```ts
export interface TypePageFields {
  /**
   * Field type definition for field 'name' (Name)
   * @name Name
   * @localized false
   * @summary Internal name, not visible to users.
   */
  name: EntryFieldTypes.Symbol;
```

The tag is only added if the field has a help text.

See related issue: https://github.com/contentful-userland/cf-content-types-generator/issues/290