### PR TITLE
ci: run tests on pull request rather than on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
`push` only works for the actual repository so pull requests from forks (like #298) don't get a CI run that gets properly associated with the CI (technically CI does still run in my fork if I've enabled actions).

I've just switched CI to triggering on pull requests rather than both pushes and PRs as I assume most changes are landed via a pull request and it avoids the same jobs being run twice for changes which reduces the carbon cost a little 🌎