### PR TITLE
refactor: apply linting to tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 /lib
 /export
-/test
 /tmp

--- a/test/cases/case-01.test.ts
+++ b/test/cases/case-01.test.ts
@@ -1,13 +1,17 @@
 import { readFileSync } from 'fs-extra';
-import * as path from 'path';
+import * as path from 'node:path';
 import CFDefinitionsBuilder from '../../src/cf-definitions-builder';
 
 function testCase(id: string, description: string) {
-  it(description, () => {
-    let builder = new CFDefinitionsBuilder();
-    const fixture = require(`./fixtures/${id}-input.json`);
-    fixture.contentTypes.forEach((contentType: any) => builder.appendType(contentType));
+  it(description, async () => {
+    const builder = new CFDefinitionsBuilder();
+    const fixture = await import(`./fixtures/${id}-input.json`);
+    for (const contentType of fixture.contentTypes) {
+      builder.appendType(contentType);
+    }
+
     expect(builder.toString()).toEqual(
+      // eslint-disable-next-line unicorn/prefer-module
       readFileSync(path.resolve(__dirname, `./fixtures/${id}-output.txt`)).toString(),
     );
   });

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -1,8 +1,8 @@
 import * as fs from 'fs-extra';
 import { writeFile } from 'fs-extra';
-//@ts-ignore
+// @ts-expect-error does not have type definitions
 import { cleanupTempDirs, createTempDir } from 'jest-fixtures';
-import * as path from 'path';
+import * as path from 'node:path';
 
 import CFDefinitionsBuilder, {
   DefaultContentTypeRenderer,
@@ -37,13 +37,10 @@ describe('A Contentful definitions builder', () => {
   it('throws on invalid input ()', () => {
     expect(() =>
       builder.appendType({
-        ...{},
         ...modelType,
-        ...{
-          sys: {
-            id: 'irrelevant',
-            type: 'UnknownType',
-          },
+        sys: {
+          id: 'irrelevant',
+          type: 'UnknownType',
         },
       }),
     ).toThrow('given data is not describing a ContentType');
@@ -65,22 +62,19 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with a required string field', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'symbolFieldId',
-            name: 'Some Symbol Field',
-            type: 'Symbol',
-            localized: false,
-            required: true,
-            validations: [],
-            disabled: false,
-            omitted: false,
-          },
-        ],
-      },
+      fields: [
+        {
+          id: 'symbolFieldId',
+          name: 'Some Symbol Field',
+          type: 'Symbol',
+          localized: false,
+          required: true,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -97,22 +91,19 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with a optional string field', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'symbolFieldId',
-            name: 'Some Symbol Field',
-            type: 'Symbol',
-            localized: false,
-            required: false,
-            validations: [],
-            disabled: false,
-            omitted: false,
-          },
-        ],
-      },
+      fields: [
+        {
+          id: 'symbolFieldId',
+          name: 'Some Symbol Field',
+          type: 'Symbol',
+          localized: false,
+          required: false,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -129,22 +120,19 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with a boolean field', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'boolFieldId',
-            name: 'Some Bool Field',
-            type: 'Boolean',
-            localized: false,
-            required: false,
-            validations: [],
-            disabled: false,
-            omitted: false,
-          },
-        ],
-      },
+      fields: [
+        {
+          id: 'boolFieldId',
+          name: 'Some Bool Field',
+          type: 'Boolean',
+          localized: false,
+          required: false,
+          validations: [],
+          disabled: false,
+          omitted: false,
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -161,27 +149,24 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with a linked entry field', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'linkFieldId',
-            name: 'Linked entry Field',
-            type: 'Link',
-            localized: false,
-            required: false,
-            validations: [
-              {
-                linkContentType: ['linkedType'],
-              },
-            ],
-            disabled: false,
-            omitted: false,
-            linkType: 'Entry',
-          },
-        ],
-      },
+      fields: [
+        {
+          id: 'linkFieldId',
+          name: 'Linked entry Field',
+          type: 'Link',
+          localized: false,
+          required: false,
+          validations: [
+            {
+              linkContentType: ['linkedType'],
+            },
+          ],
+          disabled: false,
+          omitted: false,
+          linkType: 'Entry',
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -199,31 +184,28 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with an array field', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'arrayFieldId',
-            name: 'Array Field',
-            type: 'Array',
-            localized: false,
-            required: false,
-            validations: [],
-            disabled: false,
-            omitted: false,
-            items: {
-              type: 'Link',
-              validations: [
-                {
-                  linkContentType: ['artist', 'artwork'],
-                },
-              ],
-              linkType: 'Entry',
-            },
+      fields: [
+        {
+          id: 'arrayFieldId',
+          name: 'Array Field',
+          type: 'Array',
+          localized: false,
+          required: false,
+          validations: [],
+          disabled: false,
+          omitted: false,
+          items: {
+            type: 'Link',
+            validations: [
+              {
+                linkContentType: ['artist', 'artwork'],
+              },
+            ],
+            linkType: 'Entry',
           },
-        ],
-      },
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -242,26 +224,23 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with an string field with include validation', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'stringFieldId',
-            name: 'Restricted string Field',
-            type: 'Text',
-            localized: false,
-            required: false,
-            disabled: false,
-            omitted: false,
-            validations: [
-              {
-                in: ['hello', 'world'],
-              },
-            ],
-          },
-        ],
-      },
+      fields: [
+        {
+          id: 'stringFieldId',
+          name: 'Restricted string Field',
+          type: 'Text',
+          localized: false,
+          required: false,
+          disabled: false,
+          omitted: false,
+          validations: [
+            {
+              in: ['hello', 'world'],
+            },
+          ],
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -278,26 +257,23 @@ describe('A Contentful definitions builder', () => {
 
   it('can create a definition with an numeric field with include validation', () => {
     builder.appendType({
-      ...{},
       ...modelType,
-      ...{
-        fields: [
-          {
-            id: 'numericFieldId',
-            name: 'Restricted numeric Field',
-            type: 'Integer',
-            localized: false,
-            required: false,
-            disabled: false,
-            omitted: false,
-            validations: [
-              {
-                in: ['1', '2', '3'],
-              },
-            ],
-          },
-        ],
-      },
+      fields: [
+        {
+          id: 'numericFieldId',
+          name: 'Restricted numeric Field',
+          type: 'Integer',
+          localized: false,
+          required: false,
+          disabled: false,
+          omitted: false,
+          validations: [
+            {
+              in: ['1', '2', '3'],
+            },
+          ],
+        },
+      ],
     });
     expect('\n' + builder.toString()).toEqual(
       stripIndent(`
@@ -510,8 +486,8 @@ describe('A Contentful definitions builder', () => {
       ],
     });
 
-    let beforeWriteResult: Record<string, string> = {};
-    let afterWriteResult: Record<string, string> = {};
+    const beforeWriteResult: Record<string, string> = {};
+    const afterWriteResult: Record<string, string> = {};
 
     const write = (result: Record<string, string>) => {
       return async (filePath: string, content: string) => {

--- a/test/extract-validation.test.ts
+++ b/test/extract-validation.test.ts
@@ -23,8 +23,7 @@ describe('A linkContentTypeValidations function', () => {
 
   it('parses a non array linked content type validation', () => {
     const field = { validations: [{ linkContentType: 'topicA' }] };
-    // https://github.com/contentful-userland/cf-content-types-generator/issues/148
-    // @ts-ignore
+    // @ts-expect-error https://github.com/contentful-userland/cf-content-types-generator/issues/148
     expect(linkContentTypeValidations(field)).toEqual(['topicA']);
   });
 });

--- a/test/module-name.test.ts
+++ b/test/module-name.test.ts
@@ -12,9 +12,9 @@ describe('A moduleName function', () => {
     { input: '12345', expect: 'Type12345' },
   ];
 
-  specs.forEach((spec) => {
+  for (const spec of specs) {
     it("transforms '" + spec.input + "' to valid module name '" + spec.expect + "'", () => {
       expect(moduleName(spec.input)).toEqual(spec.expect);
     });
-  });
+  }
 });

--- a/test/renderer/type/content-type-renderer.test.ts
+++ b/test/renderer/type/content-type-renderer.test.ts
@@ -74,6 +74,10 @@ describe('The default content type renderer', () => {
   });
 });
 
+const symbolTypeRenderer = () => {
+  return 'Test.Symbol';
+};
+
 describe('A derived content type renderer class', () => {
   let project: Project;
   let testFile: SourceFile;
@@ -90,10 +94,6 @@ describe('A derived content type renderer class', () => {
   });
 
   it('can return a custom field type renderer', () => {
-    const symbolTypeRenderer = () => {
-      return 'Test.Symbol';
-    };
-
     class DerivedContentTypeRenderer extends DefaultContentTypeRenderer {
       public createContext(): RenderContext {
         return {
@@ -105,6 +105,7 @@ describe('A derived content type renderer class', () => {
             if (fieldType === 'Symbol') {
               return symbolTypeRenderer as FieldRenderer<FType>;
             }
+
             return defaultRenderers[fieldType] as FieldRenderer<FType>;
           },
           imports: new Set(),

--- a/test/renderer/type/js-doc-renderer.test.ts
+++ b/test/renderer/type/js-doc-renderer.test.ts
@@ -133,7 +133,7 @@ describe('A JSDoc content type renderer class', () => {
       const defaultRenderer = new DefaultContentTypeRenderer();
       defaultRenderer.setup(project);
 
-      // @ts-ignore
+      // @ts-expect-error currently not defined
       mockContentType.sys.createdBy = {
         sys: {
           id: '<user-id>',
@@ -179,7 +179,7 @@ describe('A JSDoc content type renderer class', () => {
       const defaultRenderer = new DefaultContentTypeRenderer();
       defaultRenderer.setup(project);
 
-      // @ts-ignore
+      // @ts-expect-error currently not defined
       mockContentType.sys.publishedVersion = 5;
 
       defaultRenderer.render(mockContentType, testFile);
@@ -221,7 +221,7 @@ describe('A JSDoc content type renderer class', () => {
       const defaultRenderer = new DefaultContentTypeRenderer();
       defaultRenderer.setup(project);
 
-      // @ts-ignore
+      // @ts-expect-error currently not defined
       mockContentType.sys.firstPublishedAt = '1675420727';
 
       defaultRenderer.render(mockContentType, testFile);

--- a/test/renderer/type/localized-content-type-renfderer.test.ts
+++ b/test/renderer/type/localized-content-type-renfderer.test.ts
@@ -39,8 +39,7 @@ describe('A localized content type renderer class', () => {
             : EntryType[Key]
         };
         `
-          .replace(/.*/, '')
-          .substr(1),
+          .replace(/.*/, '').slice(1),
       ),
     );
   });

--- a/test/renderer/type/v10-content-type-renderer.test.ts
+++ b/test/renderer/type/v10-content-type-renderer.test.ts
@@ -75,6 +75,10 @@ describe('The v10 content type renderer', () => {
   });
 });
 
+const symbolTypeRenderer = () => {
+  return 'Test.Symbol';
+};
+
 describe('A derived content type renderer class', () => {
   let project: Project;
   let testFile: SourceFile;
@@ -91,10 +95,6 @@ describe('A derived content type renderer class', () => {
   });
 
   it('can return a custom field type renderer', () => {
-    const symbolTypeRenderer = () => {
-      return 'Test.Symbol';
-    };
-
     class DerivedContentTypeRenderer extends V10ContentTypeRenderer {
       public createContext(): RenderContext {
         return {
@@ -106,6 +106,7 @@ describe('A derived content type renderer class', () => {
             if (fieldType === 'Symbol') {
               return symbolTypeRenderer as FieldRenderer<FType>;
             }
+
             return defaultRenderers[fieldType] as FieldRenderer<FType>;
           },
           imports: new Set(),


### PR DESCRIPTION
I realised that `test` was for some reason excluded from linting, so I have changed that and fixed things as needed - there are a few changes that are better addressed in other ways like adding missing type properties but they should be done in dedicated PRs