### PR TITLE
feat: support specifying a prefix for generics

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ OPTIONS
   -t, --token=token              management token
   -v, --version                  show CLI version
   -a, --host                     The Management API host
-
+      --genericsPrefix=value     prefix for generics
 ```
 
 ### Example

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
+  prettierPath: null,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,5 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  prettierPath: null,
+  prettierPath: require.resolve('prettier-2'),
 };

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "oclif": "^4.1.3",
     "postinstall-postinstall": "^2.1.0",
     "prettier": "^3.0.0",
+    "prettier-2": "npm:prettier@^2",
     "semantic-release": "^19.0.2",
     "strip-indent": "^3.0.0",
     "ts-jest": "29.1.1",

--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -38,7 +38,7 @@ export default class CFDefinitionsBuilder {
     });
 
     for (const renderer of this.contentTypeRenderers) {
-      renderer.setup(this.project);
+      renderer.setup(this.project, options);
     }
   }
 

--- a/src/cf-definitions-builder.ts
+++ b/src/cf-definitions-builder.ts
@@ -11,17 +11,23 @@ import { moduleName } from './module-name';
 import { ContentTypeRenderer, DefaultContentTypeRenderer } from './renderer';
 import { CFContentType, CFEditorInterface, WriteCallback } from './types';
 import { flatten } from 'lodash';
+import { RenderContextOptions } from './renderer/type/create-default-context';
 
 export default class CFDefinitionsBuilder {
   private readonly project: Project;
 
   private readonly contentTypeRenderers: ContentTypeRenderer[];
+  private readonly renderContextOptions: RenderContextOptions;
 
-  constructor(contentTypeRenderers: ContentTypeRenderer[] = []) {
+  constructor(
+    contentTypeRenderers: ContentTypeRenderer[] = [],
+    options: RenderContextOptions = {},
+  ) {
     if (contentTypeRenderers.length === 0) {
       contentTypeRenderers.push(new DefaultContentTypeRenderer());
     }
 
+    this.renderContextOptions = options;
     this.contentTypeRenderers = contentTypeRenderers;
     this.project = new Project({
       useInMemoryFileSystem: true,
@@ -46,7 +52,7 @@ export default class CFDefinitionsBuilder {
 
     const file = this.addFile(moduleName(model.sys.id));
     for (const renderer of this.contentTypeRenderers) {
-      renderer.render(model, file, editorInterface);
+      renderer.render(model, file, editorInterface, this.renderContextOptions);
     }
 
     file.organizeImports({

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -30,6 +30,8 @@ class ContentfulMdg extends Command {
     jsdoc: Flags.boolean({ char: 'd', description: 'add JSDoc comments' }),
     typeguard: Flags.boolean({ char: 'g', description: 'add type guards' }),
 
+    genericsPrefix: Flags.string({ description: 'prefix for generics', default: '' }),
+
     // remote access
     spaceId: Flags.string({ char: 's', description: 'space id' }),
     token: Flags.string({
@@ -96,7 +98,7 @@ class ContentfulMdg extends Command {
 
     const editorInterfaces = content.editorInterfaces as CFEditorInterface[] | undefined;
 
-    const builder = new CFDefinitionsBuilder(renderers);
+    const builder = new CFDefinitionsBuilder(renderers, { genericsPrefix: flags.genericsPrefix });
     for (const model of content.contentTypes) {
       const editorInterface = editorInterfaces?.find(
         (e) => e.sys.contentType.sys.id === model.sys.id,

--- a/src/renderer/type/base-content-type-renderer.ts
+++ b/src/renderer/type/base-content-type-renderer.ts
@@ -1,6 +1,6 @@
 import { Project, SourceFile } from 'ts-morph';
 import { CFContentType, CFEditorInterface } from '../../types';
-import { ContentTypeRenderer } from './content-type-renderer';
+import { ContentTypeRenderer, SetupOptions } from './content-type-renderer';
 import {
   createDefaultContext,
   RenderContext,
@@ -8,7 +8,7 @@ import {
 } from './create-default-context';
 
 export class BaseContentTypeRenderer implements ContentTypeRenderer {
-  setup(project: Project): void {
+  setup(project: Project, options: SetupOptions = {}): void {
     /**/
   }
 

--- a/src/renderer/type/base-content-type-renderer.ts
+++ b/src/renderer/type/base-content-type-renderer.ts
@@ -1,19 +1,28 @@
 import { Project, SourceFile } from 'ts-morph';
-import { CFContentType } from '../../types';
+import { CFContentType, CFEditorInterface } from '../../types';
 import { ContentTypeRenderer } from './content-type-renderer';
-import { createDefaultContext, RenderContext } from './create-default-context';
+import {
+  createDefaultContext,
+  RenderContext,
+  RenderContextOptions,
+} from './create-default-context';
 
 export class BaseContentTypeRenderer implements ContentTypeRenderer {
   setup(project: Project): void {
     /**/
   }
 
-  public render(contentType: CFContentType, file: SourceFile): void {
+  public render(
+    contentType: CFContentType,
+    file: SourceFile,
+    editorInterface?: CFEditorInterface,
+    contextOptions: RenderContextOptions = {},
+  ): void {
     file.addStatements(`/* Types for ${contentType.sys.id} */`);
   }
 
-  public createContext(): RenderContext {
-    return createDefaultContext();
+  public createContext(options: RenderContextOptions = {}): RenderContext {
+    return createDefaultContext(options);
   }
 
   additionalFiles(): SourceFile[] {

--- a/src/renderer/type/content-type-renderer.ts
+++ b/src/renderer/type/content-type-renderer.ts
@@ -1,13 +1,18 @@
 import { Project, SourceFile } from 'ts-morph';
 import { CFContentType, CFEditorInterface } from '../../types';
-import { RenderContext } from './create-default-context';
+import { RenderContext, RenderContextOptions } from './create-default-context';
 
 export interface ContentTypeRenderer {
   setup(project: Project): void;
 
-  render(contentType: CFContentType, file: SourceFile, editorInterface?: CFEditorInterface): void;
+  render(
+    contentType: CFContentType,
+    file: SourceFile,
+    editorInterface?: CFEditorInterface,
+    contextOptions?: RenderContextOptions,
+  ): void;
 
-  createContext(): RenderContext;
+  createContext(options?: RenderContextOptions): RenderContext;
 
   additionalFiles(): SourceFile[];
 }

--- a/src/renderer/type/content-type-renderer.ts
+++ b/src/renderer/type/content-type-renderer.ts
@@ -2,8 +2,10 @@ import { Project, SourceFile } from 'ts-morph';
 import { CFContentType, CFEditorInterface } from '../../types';
 import { RenderContext, RenderContextOptions } from './create-default-context';
 
+export type SetupOptions = RenderContextOptions;
+
 export interface ContentTypeRenderer {
-  setup(project: Project): void;
+  setup(project: Project, options?: SetupOptions): void;
 
   render(
     contentType: CFContentType,

--- a/src/renderer/type/create-default-context.ts
+++ b/src/renderer/type/create-default-context.ts
@@ -3,6 +3,10 @@ import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
 import { moduleFieldsName, moduleName, moduleSkeletonName } from '../../module-name';
 import { defaultRenderers, FieldRenderer } from '../field';
 
+export type RenderContextOptions = {
+  genericsPrefix?: string;
+};
+
 export type RenderContext = {
   getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;
   moduleName: (id: string) => string;
@@ -10,9 +14,12 @@ export type RenderContext = {
   moduleReferenceName: (id: string) => string;
   moduleSkeletonName: (id: string) => string;
   imports: Set<OptionalKind<ImportDeclarationStructure>>;
+  genericsPrefix?: string;
 };
 
-export const createDefaultContext = (): RenderContext => {
+export const createDefaultContext = ({
+  genericsPrefix = '',
+}: RenderContextOptions = {}): RenderContext => {
   return {
     moduleName,
     moduleFieldsName,
@@ -21,5 +28,6 @@ export const createDefaultContext = (): RenderContext => {
     getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) =>
       defaultRenderers[fieldType] as FieldRenderer<FType>,
     imports: new Set(),
+    genericsPrefix,
   };
 };

--- a/src/renderer/type/create-v10-context.ts
+++ b/src/renderer/type/create-v10-context.ts
@@ -1,21 +1,15 @@
 import { ContentTypeFieldType } from 'contentful';
-import { ImportDeclarationStructure, OptionalKind } from 'ts-morph';
 import { FieldRenderer, v10Renderers } from '../field';
-import { createDefaultContext } from './create-default-context';
+import {
+  createDefaultContext,
+  RenderContext,
+  RenderContextOptions,
+} from './create-default-context';
 import { moduleSkeletonName } from '../../module-name';
 
-export type RenderContext = {
-  getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) => FieldRenderer<FType>;
-  moduleName: (id: string) => string;
-  moduleFieldsName: (id: string) => string;
-  moduleReferenceName: (id: string) => string;
-  moduleSkeletonName: (id: string) => string;
-  imports: Set<OptionalKind<ImportDeclarationStructure>>;
-};
-
-export const createV10Context = (): RenderContext => {
+export const createV10Context = (options: RenderContextOptions = {}): RenderContext => {
   return {
-    ...createDefaultContext(),
+    ...createDefaultContext(options),
     moduleReferenceName: moduleSkeletonName,
     getFieldRenderer: <FType extends ContentTypeFieldType>(fieldType: FType) =>
       v10Renderers[fieldType] as FieldRenderer<FType>,

--- a/src/renderer/type/default-content-type-renderer.ts
+++ b/src/renderer/type/default-content-type-renderer.ts
@@ -7,13 +7,18 @@ import {
 } from 'ts-morph';
 import { propertyImports } from '../../property-imports';
 import { renderTypeGeneric } from '../generic';
-import { CFContentType } from '../../types';
+import { CFContentType, CFEditorInterface } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
-import { RenderContext } from './create-default-context';
+import { RenderContext, RenderContextOptions } from './create-default-context';
 
 export class DefaultContentTypeRenderer extends BaseContentTypeRenderer {
-  public render(contentType: CFContentType, file: SourceFile): void {
-    const context = this.createContext();
+  public render(
+    contentType: CFContentType,
+    file: SourceFile,
+    editorInterface?: CFEditorInterface,
+    contextOptions: RenderContextOptions = {},
+  ): void {
+    const context = this.createContext(contextOptions);
 
     this.addDefaultImports(context);
     this.renderFieldsInterface(contentType, file, context);

--- a/src/renderer/type/js-doc-renderer.ts
+++ b/src/renderer/type/js-doc-renderer.ts
@@ -3,6 +3,7 @@ import { ContentTypeProps } from 'contentful-management';
 import { JSDocStructure, JSDocTagStructure, OptionalKind, SourceFile } from 'ts-morph';
 import { CFContentType, CFEditorInterface, CFEditorInterfaceControl } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
+import { RenderContextOptions } from './create-default-context';
 
 type EntryDocsOptionsProps = {
   /* Name of generated Entry type */
@@ -184,8 +185,9 @@ export class JsDocRenderer extends BaseContentTypeRenderer {
     contentType: CFContentType,
     file: SourceFile,
     editorInterface?: CFEditorInterface,
+    contextOptions: RenderContextOptions = {},
   ): void => {
-    const context = this.createContext();
+    const context = this.createContext(contextOptions);
 
     const entryInterfaceName = context.moduleName(contentType.sys.id);
     const entryInterface = file.getTypeAlias(entryInterfaceName);

--- a/src/renderer/type/localized-content-type-renderer.ts
+++ b/src/renderer/type/localized-content-type-renderer.ts
@@ -26,36 +26,26 @@ export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
       },
     );
 
+    const { genericsPrefix = '' } = options;
+
     file.addStatements('/* Utility types for localized entries */');
     file.addTypeAlias({
-      name: `LocalizedFields<${options.genericsPrefix ?? ''}Fields, ${
-        options.genericsPrefix ?? ''
-      }Locales extends keyof any>`,
+      name: `LocalizedFields<${genericsPrefix}Fields, ${genericsPrefix}Locales extends keyof any>`,
       isExported: true,
       type: `{
-                [${options.genericsPrefix ?? ''}FieldName in keyof ${
-        options.genericsPrefix ?? ''
-      }Fields]?: {
-                    [${options.genericsPrefix ?? ''}LocaleName in ${
-        options.genericsPrefix ?? ''
-      }Locales]?: ${options.genericsPrefix ?? ''}Fields[${options.genericsPrefix ?? ''}FieldName];
+                [${genericsPrefix}FieldName in keyof ${genericsPrefix}Fields]?: {
+                    [${genericsPrefix}LocaleName in ${genericsPrefix}Locales]?: ${genericsPrefix}Fields[${genericsPrefix}FieldName];
                 }
             }`,
     });
     file.addTypeAlias({
-      name: `LocalizedEntry<${options.genericsPrefix ?? ''}EntryType, ${
-        options.genericsPrefix ?? ''
-      }Locales extends keyof any>`,
+      name: `LocalizedEntry<${genericsPrefix}EntryType, ${genericsPrefix}Locales extends keyof any>`,
       isExported: true,
       type: `{
-                [${options.genericsPrefix ?? ''}Key in keyof ${
-        options.genericsPrefix ?? ''
-      }EntryType]:
-                ${options.genericsPrefix ?? ''}Key extends 'fields'
-                    ? LocalizedFields<${options.genericsPrefix ?? ''}EntryType[${
-        options.genericsPrefix ?? ''
-      }Key], ${options.genericsPrefix ?? ''}Locales>
-                    : ${options.genericsPrefix ?? ''}EntryType[${options.genericsPrefix ?? ''}Key]
+                [${genericsPrefix}Key in keyof ${genericsPrefix}EntryType]:
+                ${genericsPrefix}Key extends 'fields'
+                    ? LocalizedFields<${genericsPrefix}EntryType[${genericsPrefix}Key], ${genericsPrefix}Locales>
+                    : ${genericsPrefix}EntryType[${genericsPrefix}Key]
             }`,
     });
 

--- a/src/renderer/type/localized-content-type-renderer.ts
+++ b/src/renderer/type/localized-content-type-renderer.ts
@@ -3,6 +3,7 @@ import { renderTypeGeneric } from '../generic';
 import { CFContentType, CFEditorInterface } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
 import { RenderContextOptions } from './create-default-context';
+import { SetupOptions } from './content-type-renderer';
 
 export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
   private readonly FILE_BASE_NAME = 'Localized';
@@ -14,7 +15,7 @@ export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
     this.files = [];
   }
 
-  setup(project: Project): void {
+  setup(project: Project, options: SetupOptions = {}): void {
     const file = project.createSourceFile(
       `${this.FILE_BASE_NAME}.ts`,
       // eslint-disable-next-line no-warning-comments
@@ -27,22 +28,34 @@ export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
 
     file.addStatements('/* Utility types for localized entries */');
     file.addTypeAlias({
-      name: 'LocalizedFields<Fields, Locales extends keyof any>',
+      name: `LocalizedFields<${options.genericsPrefix ?? ''}Fields, ${
+        options.genericsPrefix ?? ''
+      }Locales extends keyof any>`,
       isExported: true,
       type: `{
-                [FieldName in keyof Fields]?: {
-                    [LocaleName in Locales]?: Fields[FieldName];
+                [${options.genericsPrefix ?? ''}FieldName in keyof ${
+        options.genericsPrefix ?? ''
+      }Fields]?: {
+                    [${options.genericsPrefix ?? ''}LocaleName in ${
+        options.genericsPrefix ?? ''
+      }Locales]?: ${options.genericsPrefix ?? ''}Fields[${options.genericsPrefix ?? ''}FieldName];
                 }
             }`,
     });
     file.addTypeAlias({
-      name: 'LocalizedEntry<EntryType, Locales extends keyof any>',
+      name: `LocalizedEntry<${options.genericsPrefix ?? ''}EntryType, ${
+        options.genericsPrefix ?? ''
+      }Locales extends keyof any>`,
       isExported: true,
       type: `{
-                [Key in keyof EntryType]:
-                Key extends 'fields'
-                    ? LocalizedFields<EntryType[Key], Locales>
-                    : EntryType[Key]
+                [${options.genericsPrefix ?? ''}Key in keyof ${
+        options.genericsPrefix ?? ''
+      }EntryType]:
+                ${options.genericsPrefix ?? ''}Key extends 'fields'
+                    ? LocalizedFields<${options.genericsPrefix ?? ''}EntryType[${
+        options.genericsPrefix ?? ''
+      }Key], ${options.genericsPrefix ?? ''}Locales>
+                    : ${options.genericsPrefix ?? ''}EntryType[${options.genericsPrefix ?? ''}Key]
             }`,
     });
 

--- a/src/renderer/type/localized-content-type-renderer.ts
+++ b/src/renderer/type/localized-content-type-renderer.ts
@@ -1,7 +1,8 @@
 import { Project, SourceFile } from 'ts-morph';
 import { renderTypeGeneric } from '../generic';
-import { CFContentType } from '../../types';
+import { CFContentType, CFEditorInterface } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
+import { RenderContextOptions } from './create-default-context';
 
 export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
   private readonly FILE_BASE_NAME = 'Localized';
@@ -49,24 +50,35 @@ export class LocalizedContentTypeRenderer extends BaseContentTypeRenderer {
     this.files.push(file);
   }
 
-  render(contentType: CFContentType, file: SourceFile): void {
-    const context = this.createContext();
+  render(
+    contentType: CFContentType,
+    file: SourceFile,
+    editorInterface?: CFEditorInterface,
+    contextOptions: RenderContextOptions = {},
+  ): void {
+    const context = this.createContext(contextOptions);
 
     file.addTypeAlias({
-      name: `Localized${context.moduleFieldsName(contentType.sys.id)}<Locales extends keyof any>`,
+      name: `Localized${context.moduleFieldsName(contentType.sys.id)}<${
+        context.genericsPrefix ?? ''
+      }Locales extends keyof any>`,
       isExported: true,
       type: renderTypeGeneric(
         'LocalizedFields',
-        `${context.moduleFieldsName(contentType.sys.id)}, Locales`,
+        context.moduleFieldsName(contentType.sys.id),
+        `${context.genericsPrefix ?? ''}Locales`,
       ),
     });
 
     file.addTypeAlias({
-      name: `Localized${context.moduleName(contentType.sys.id)}<Locales extends keyof any>`,
+      name: `Localized${context.moduleName(contentType.sys.id)}<${
+        context.genericsPrefix ?? ''
+      }Locales extends keyof any>`,
       isExported: true,
       type: renderTypeGeneric(
         'LocalizedEntry',
-        `${context.moduleName(contentType.sys.id)}, Locales`,
+        context.moduleName(contentType.sys.id),
+        `${context.genericsPrefix ?? ''}Locales`,
       ),
     });
 

--- a/src/renderer/type/v10-content-type-renderer.ts
+++ b/src/renderer/type/v10-content-type-renderer.ts
@@ -7,14 +7,19 @@ import {
 } from 'ts-morph';
 import { propertyImports } from '../../property-imports';
 import { renderTypeGeneric } from '../generic';
-import { CFContentType } from '../../types';
+import { CFContentType, CFEditorInterface } from '../../types';
 import { BaseContentTypeRenderer } from './base-content-type-renderer';
-import { RenderContext } from './create-default-context';
+import { RenderContext, RenderContextOptions } from './create-default-context';
 import { createV10Context } from './create-v10-context';
 
 export class V10ContentTypeRenderer extends BaseContentTypeRenderer {
-  public render(contentType: CFContentType, file: SourceFile): void {
-    const context = this.createContext();
+  public render(
+    contentType: CFContentType,
+    file: SourceFile,
+    editorInterface?: CFEditorInterface,
+    contextOptions: RenderContextOptions = {},
+  ): void {
+    const context = this.createContext(contextOptions);
 
     this.addDefaultImports(context);
     this.renderFieldsInterface(contentType, file, context);
@@ -101,8 +106,8 @@ export class V10ContentTypeRenderer extends BaseContentTypeRenderer {
     return {
       name: renderTypeGeneric(
         context.moduleName(contentType.sys.id),
-        'Modifiers extends ChainModifiers',
-        'Locales extends LocaleCode',
+        `${context.genericsPrefix ?? ''}Modifiers extends ChainModifiers`,
+        `${context.genericsPrefix ?? ''}Locales extends LocaleCode`,
       ),
       isExported: true,
       type: this.renderEntryType(contentType, context),
@@ -119,12 +124,12 @@ export class V10ContentTypeRenderer extends BaseContentTypeRenderer {
     return renderTypeGeneric(
       'Entry',
       context.moduleSkeletonName(contentType.sys.id),
-      'Modifiers',
-      'Locales',
+      `${context.genericsPrefix ?? ''}Modifiers`,
+      `${context.genericsPrefix ?? ''}Locales`,
     );
   }
 
-  public createContext(): RenderContext {
-    return createV10Context();
+  public createContext(options: RenderContextOptions = {}): RenderContext {
+    return createV10Context(options);
   }
 }

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -550,22 +550,22 @@ describe('A Contentful definitions builder', () => {
     expect('\n' + builder.toString()).toMatchInlineSnapshot(`
       "
       import type { Entry } from "contentful";
-      
-      export type LocalizedFields<Fields, Locales extends keyof any> = {
-          [FieldName in keyof Fields]?: {
-              [LocaleName in Locales]?: Fields[FieldName];
+
+      export type LocalizedFields<TFields, TLocales extends keyof any> = {
+          [TFieldName in keyof TFields]?: {
+              [TLocaleName in TLocales]?: TFields[TFieldName];
           }
       };
-      export type LocalizedEntry<EntryType, Locales extends keyof any> = {
-          [Key in keyof EntryType]:
-          Key extends 'fields'
-          ? LocalizedFields<EntryType[Key], Locales>
-          : EntryType[Key]
+      export type LocalizedEntry<TEntryType, TLocales extends keyof any> = {
+          [TKey in keyof TEntryType]:
+          TKey extends 'fields'
+          ? LocalizedFields<TEntryType[TKey], TLocales>
+          : TEntryType[TKey]
       };
-      
+
       export interface TypeSysIdFields {
       }
-      
+
       export type TypeSysId = Entry<TypeSysIdFields>;
       export type LocalizedTypeSysIdFields<TLocales extends keyof any> = LocalizedFields<TypeSysIdFields, TLocales>;
       export type LocalizedTypeSysId<TLocales extends keyof any> = LocalizedEntry<TypeSysId, TLocales>;

--- a/test/cf-definitions-builder.test.ts
+++ b/test/cf-definitions-builder.test.ts
@@ -539,6 +539,40 @@ describe('A Contentful definitions builder', () => {
     );
   });
 
+  it('passes on the generics prefix', async () => {
+    builder = new CFDefinitionsBuilder(
+      [new DefaultContentTypeRenderer(), new LocalizedContentTypeRenderer()],
+      { genericsPrefix: 'T' },
+    );
+
+    builder.appendType(modelType);
+
+    expect('\n' + builder.toString()).toMatchInlineSnapshot(`
+      "
+      import type { Entry } from "contentful";
+      
+      export type LocalizedFields<Fields, Locales extends keyof any> = {
+          [FieldName in keyof Fields]?: {
+              [LocaleName in Locales]?: Fields[FieldName];
+          }
+      };
+      export type LocalizedEntry<EntryType, Locales extends keyof any> = {
+          [Key in keyof EntryType]:
+          Key extends 'fields'
+          ? LocalizedFields<EntryType[Key], Locales>
+          : EntryType[Key]
+      };
+      
+      export interface TypeSysIdFields {
+      }
+      
+      export type TypeSysId = Entry<TypeSysIdFields>;
+      export type LocalizedTypeSysIdFields<TLocales extends keyof any> = LocalizedFields<TypeSysIdFields, TLocales>;
+      export type LocalizedTypeSysId<TLocales extends keyof any> = LocalizedEntry<TypeSysId, TLocales>;
+      "
+    `);
+  });
+
   it('exports type guard functions', async () => {
     builder = new CFDefinitionsBuilder([new DefaultContentTypeRenderer(), new TypeGuardRenderer()]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7717,6 +7717,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+"prettier-2@npm:prettier@^2":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
 prettier@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.1.1.tgz#6ba9f23165d690b6cbdaa88cb0807278f7019848"


### PR DESCRIPTION
Resolves part of #292

---

This is working and I think overall a good start but it's not the prettiest because it requires adding support for the general concept of a generation config that is available to different parts and depths of the generators and some of the ways of doing this could be considered breaking changes depending on the focus of the library (e.g. are type-only changes considered breaking? new parameters in methods that would break `super` calls? etc); hence I'm opening this as a draft so I can get feedback on the preferred way to handle this before I finish this off.

I have tested this with the contentful project I'm working on and confirmed the types being generated now pass our [`naming-convention`](https://github.com/ackama/eslint-config-ackama/blob/main/%40typescript-eslint.js#L25-L67) configuration 🎉 