### PR TITLE
use optional chaining in the type guard for greater safety

### DIFF
--- a/src/renderer/type/type-guard-renderer.ts
+++ b/src/renderer/type/type-guard-renderer.ts
@@ -50,7 +50,7 @@ export class TypeGuardRenderer extends BaseContentTypeRenderer {
           type: TypeGuardRenderer.WithContentTypeLink,
         },
       ],
-      statements: `return entry.sys.contentType.sys.id === '${contentType.sys.id}'`,
+      statements: `return entry?.sys?.contentType?.sys?.id === '${contentType.sys.id}'`,
     });
 
     file.organizeImports({


### PR DESCRIPTION
The generated `is{entryName}` functions are only useful if you're confident that the thing you're passing in is, at least, a fully-fleshed-out `Entry` type. But it's possible to not know what exactly you have. In my case, I have a situation where my object is either a string, an unresolved link, or one of three entry types. And in that case the caller of `is{entryName}` will need to do additional checks to make sure it's even safe to call this function, or risk throwing an exception. Better to have the function just behave safely and do its job all the way.

As a general practice in TS, `isXYZ` functions should be safe to call with any argument.