### PR TITLE
Allow undefined in V10 typeguard

### DIFF
--- a/src/renderer/type/v10-type-guard-renderer.ts
+++ b/src/renderer/type/v10-type-guard-renderer.ts
@@ -38,9 +38,10 @@ export class V10TypeGuardRenderer extends BaseContentTypeRenderer {
         {
           name: 'entry',
           type: renderTypeGeneric('Entry', 'EntrySkeletonType', 'Modifiers', 'Locales'),
+          hasQuestionToken: true,
         },
       ],
-      statements: `return entry.sys.contentType.sys.id === '${contentType.sys.id}'`,
+      statements: `return entry?.sys?.contentType?.sys?.id === '${contentType.sys.id}'`,
     });
 
     file.organizeImports({

--- a/test/renderer/type/v10-type-guard-renderer.test.ts
+++ b/test/renderer/type/v10-type-guard-renderer.test.ts
@@ -1,0 +1,85 @@
+import { Project, ScriptTarget, SourceFile } from 'ts-morph';
+import { CFContentType, DefaultContentTypeRenderer, V10TypeGuardRenderer } from '../../../src';
+import stripIndent = require('strip-indent');
+
+describe('A content type type guard renderer class', () => {
+  let project: Project;
+  let testFile: SourceFile;
+  let mockContentType: CFContentType;
+
+  beforeEach(() => {
+    project = new Project({
+      useInMemoryFileSystem: true,
+      compilerOptions: {
+        target: ScriptTarget.ES5,
+        declaration: true,
+      },
+    });
+
+    mockContentType = {
+      name: 'Animal',
+      sys: {
+        id: 'animal',
+        type: 'Symbol',
+      },
+      fields: [
+        {
+          id: 'bread',
+          name: 'Bread',
+          disabled: false,
+          localized: false,
+          required: true,
+          type: 'Symbol',
+          omitted: false,
+          validations: [],
+        },
+      ],
+    };
+
+    testFile = project.createSourceFile('test.ts');
+  });
+
+  describe('with default content type declarations', () => {
+    it('renders entry type guard', () => {
+      const defaultRenderer = new DefaultContentTypeRenderer();
+      defaultRenderer.setup(project);
+      defaultRenderer.render(mockContentType, testFile);
+
+      const typeGuardRenderer = new V10TypeGuardRenderer();
+      typeGuardRenderer.render(mockContentType, testFile);
+
+      expect('\n' + testFile.getFullText()).toEqual(
+        stripIndent(`
+        import type { ChainModifiers, Entry, EntryFields, LocaleCode } from "contentful";
+        
+        export interface TypeAnimalFields {
+            bread: EntryFields.Symbol;
+        }
+        
+        export type TypeAnimal = Entry<TypeAnimalFields>;
+        
+        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
+            return entry.sys.contentType.sys.id === 'animal'
+        }
+        `),
+      );
+    });
+
+    it('creates type guard helper types', () => {
+      const typeGuardRenderer = new V10TypeGuardRenderer();
+      typeGuardRenderer.setup(project);
+      typeGuardRenderer.render(mockContentType, testFile);
+      const typeGuardFile = project.getSourceFiles()[0];
+
+      expect('\n' + typeGuardFile.getFullText()).toEqual(
+        stripIndent(`
+        import type { ChainModifiers, Entry, LocaleCode } from "contentful";
+
+        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
+            return entry.sys.contentType.sys.id === 'animal'
+        }
+        `),
+      );
+    });
+  });
+});

--- a/test/renderer/type/v10-type-guard-renderer.test.ts
+++ b/test/renderer/type/v10-type-guard-renderer.test.ts
@@ -58,8 +58,8 @@ describe('A content type type guard renderer class', () => {
         
         export type TypeAnimal = Entry<TypeAnimalFields>;
         
-        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
-            return entry.sys.contentType.sys.id === 'animal'
+        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry?: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
+            return entry?.sys?.contentType?.sys?.id === 'animal'
         }
         `),
       );
@@ -75,8 +75,8 @@ describe('A content type type guard renderer class', () => {
         stripIndent(`
         import type { ChainModifiers, Entry, LocaleCode } from "contentful";
 
-        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
-            return entry.sys.contentType.sys.id === 'animal'
+        export function isTypeAnimal<Modifiers extends ChainModifiers, Locales extends LocaleCode>(entry?: Entry<EntrySkeletonType, Modifiers, Locales>): entry is TypeAnimal<Modifiers, Locales> {
+            return entry?.sys?.contentType?.sys?.id === 'animal'
         }
         `),
       );


### PR DESCRIPTION
* Updates the V10 typeguard renderer to allow undefined values passed to the function
* Adds tests for the V10 typeguard renderer output


Builds on top of https://github.com/contentful-userland/cf-content-types-generator/pull/389 and would close that PR