### PR TITLE
feat: accept resource links to native external references in v10 type generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@oclif/core": "^3.27.0",
     "@oclif/plugin-help": "^6.2.8",
-    "contentful": "^10.14.1",
+    "contentful": "^10.15.1",
     "contentful-export": "^7.19.147",
     "contentful-management": "^11.31.6",
     "fs-extra": "^11.2.0",

--- a/src/renderer/field/render-prop-resource-link.ts
+++ b/src/renderer/field/render-prop-resource-link.ts
@@ -18,21 +18,40 @@ export const renderPropResourceLink = (field: ContentTypeField, context: RenderC
   return renderTypeGeneric('Entry', 'Record<string, any>');
 };
 
+const EntryResourceType = renderTypeGeneric('EntryFieldTypes.EntryResourceLink', 'EntrySkeletonType');
+const ExternalResourceType = 'EntryFieldTypes.ExternalResourceLink';
+
 export const renderPropResourceLinkV10 = (
   field: ContentTypeField,
   context: RenderContext,
 ): string => {
+  const resourceTypes = new Set() as Set<string>;
   for (const resource of field.allowedResources!) {
     if (resource.type !== 'Contentful:Entry') {
-      throw new Error(`Unknown type "${resource.type}"`);
+      if (resource.source) {
+        // We have a cross-space reference that's not to an Entry, throw an error
+        throw new Error(`Unknown type "${resource.type}"`);
+      }
+
+      // Handle native external references
+      console.log(`Unknown external (?) resource link type "${resource.type}"`);
+      if (!resourceTypes.has(ExternalResourceType)) {
+        context.imports.add({
+            moduleSpecifier: 'contentful',
+            namedImports: ['EntryFieldTypes', 'ExternalResourceLink'],
+            isTypeOnly: true,
+        });
+        resourceTypes.add(ExternalResourceType);
+      }
+    } else if (!resourceTypes.has(EntryResourceType)) {
+      context.imports.add({
+        moduleSpecifier: 'contentful',
+        namedImports: ['EntryFieldTypes', 'EntrySkeletonType'],
+        isTypeOnly: true,
+      });
+      resourceTypes.add(EntryResourceType);
     }
   }
 
-  context.imports.add({
-    moduleSpecifier: 'contentful',
-    namedImports: ['EntryFieldTypes', 'EntrySkeletonType'],
-    isTypeOnly: true,
-  });
-
-  return renderTypeGeneric('EntryFieldTypes.EntryResourceLink', 'EntrySkeletonType');
+  return [...resourceTypes].join(" | ");
 };

--- a/test/renderer/field/render-prop-resource-link.test.ts
+++ b/test/renderer/field/render-prop-resource-link.test.ts
@@ -33,7 +33,7 @@ describe('A renderPropResourceLink function', () => {
     );
   });
 
-  it('rejects a "ResourceLink" with an unknown resource type', () => {
+  it('rejects a "ResourceLink" with a space and unknown resource type', () => {
     const field = JSON.parse(`
         {
           "id": "category",
@@ -115,6 +115,73 @@ describe('A renderPropResourceLinkV10 function', () => {
 
     expect(() => renderPropResourceLinkV10(field, createDefaultContext())).toThrow(
       'Unknown type "Contentful:UnknownEntity"',
+    );
+  });
+
+  it('Treats a "ResourceLink" with an unknown resource type and no space as an external resource', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "ResourceLink",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "allowedResources": [
+            {
+              "type": "ExternalProvider:ExternalReference"
+            }
+          ]
+          }
+      `);
+
+    expect(renderPropResourceLinkV10(field, createDefaultContext())).toEqual(
+      'EntryFieldTypes.ExternalResourceLink',
+    );
+  });
+
+  it('Handles "ResourceLink" with mix of cross-space and external references', () => {
+    const field = JSON.parse(`
+        {
+          "id": "category",
+          "name": "Category",
+          "type": "ResourceLink",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "allowedResources": [
+            {
+              "type": "Contentful:Entry",
+              "source": "crn:contentful:::content:spaces/spaceId",
+                "contentTypes": [
+                "topicCategory",
+                "topicCategory2"
+              ]
+            },
+            {
+              "type": "Contentful:Entry",
+              "source": "crn:contentful:::content:spaces/spaceId2",
+                "contentTypes": [
+                "topicCategory3",
+                "topicCategory4"
+              ]
+            },
+            {
+              "type": "ExternalProvider:ExternalReference1"
+            },
+            {
+              "type": "ExternalProvider:ExternalReference2"
+            }
+          ]
+        }
+      `);
+
+    expect(renderPropResourceLinkV10(field, createDefaultContext())).toEqual(
+      'EntryFieldTypes.EntryResourceLink<EntrySkeletonType> | EntryFieldTypes.ExternalResourceLink',
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -956,6 +956,14 @@
   resolved "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz"
   integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
 
+"@contentful/content-source-maps@^0.11.0":
+  version "0.11.10"
+  resolved "https://registry.yarnpkg.com/@contentful/content-source-maps/-/content-source-maps-0.11.10.tgz#c038231cce8abfefd7cd22fb828630227baa29da"
+  integrity sha512-nD1d5r3AL6ACmoWjkHrdrV9VCg7nxQw9T0SC7I4tClMaRQHW075sfO0zybBhHHTthDXL6pH+NvSlNoD2jOdxqg==
+  dependencies:
+    "@vercel/stega" "^0.1.2"
+    json-pointer "^0.6.2"
+
 "@contentful/content-source-maps@^0.6.0":
   version "0.6.1"
   resolved "https://registry.npmjs.org/@contentful/content-source-maps/-/content-source-maps-0.6.1.tgz"
@@ -3716,7 +3724,20 @@ contentful-sdk-core@^8.3.1:
     p-throttle "^4.1.1"
     qs "^6.11.2"
 
-contentful@^10.14.1, contentful@^10.6.9:
+contentful@^10.15.1:
+  version "10.15.2"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.15.2.tgz#f36368e3b5c9e47088a7d7ec7b426c2005fe67c0"
+  integrity sha512-JJ+qFzxDtbQ4FfPdRF01OVFagy2ZGDHKakgsLTIj2sdnCRa6sAgTMW+jmbMkDX0B8nDRbUng6A7inRLRdLxHcw==
+  dependencies:
+    "@contentful/content-source-maps" "^0.11.0"
+    "@contentful/rich-text-types" "^16.6.1"
+    axios "^1.7.4"
+    contentful-resolve-response "^1.9.0"
+    contentful-sdk-core "^8.3.1"
+    json-stringify-safe "^5.0.1"
+    type-fest "^4.0.0"
+
+contentful@^10.6.9:
   version "10.14.1"
   resolved "https://registry.yarnpkg.com/contentful/-/contentful-10.14.1.tgz#a639994acc56ffa40d1fd5d4fb308c752129c6bf"
   integrity sha512-ZBmJwohQqldXW7sxBCcucKPLO6JdZK+G+aKVxA2EG2nKY13jY8DNSAk8cQS2tc7Wj9C14haQpzbzqKnErSQ8/w==


### PR DESCRIPTION
Trying to use `cf-content-types-generator` with a Contentful schema that includes fields with native external references currently results in an exception and failure to generate types. This PR updates `renderPropResourceLinkV10` to recognize the `ExternalResourceLink` type and allow it. When encountering an unknown `allowedResources` value it logs the value and treats it as `EntryFieldTypes.ExternalResourceLink`. Includes updated tests.