### PR TITLE
fix: stringify string literals correctly

### DIFF
--- a/src/renderer/generic/render-type-literal.ts
+++ b/src/renderer/generic/render-type-literal.ts
@@ -1,3 +1,3 @@
 export const renderTypeLiteral = (value: string): string => {
-  return `"${value}"`;
+  return JSON.stringify(value);
 };

--- a/test/rendered/generic/render-type-literal.test.ts
+++ b/test/rendered/generic/render-type-literal.test.ts
@@ -6,5 +6,5 @@ describe('A renderTypeLiteral function', () => {
     });
     it('renders a string with an escapable character', () => {
         expect(renderTypeLiteral('foo\nbar')).toEqual('"foo\\nbar"');
-    });    
+    });
 });

--- a/test/rendered/generic/render-type-literal.test.ts
+++ b/test/rendered/generic/render-type-literal.test.ts
@@ -1,0 +1,10 @@
+import { renderTypeLiteral } from '../../../src/renderer/generic/render-type-literal';
+
+describe('A renderTypeLiteral function', () => {
+    it('renders a plain string', () => {
+        expect(renderTypeLiteral('foo')).toEqual('"foo"');
+    });
+    it('renders a string with an escapable character', () => {
+        expect(renderTypeLiteral('foo\nbar')).toEqual('"foo\\nbar"');
+    });    
+});


### PR DESCRIPTION
Fixes #415 

Use `JSON.stringify` to render string literals.

This means that e.g. if you have a string `"a\nb"` when it's rendered into the output Typescript instead of 

```
"a
b"
```

which is a syntax error, you will get

```
"a\nb"
```

as desired, and so on for other sequences that should be escaped when serialising a string.


